### PR TITLE
2 hide energy consumption of joularjx thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ JoularJX can be configured by modifying the ```config.properties``` files:
 - ```logger-level```: set the level of information (by logger) given by JoularJX in the terminal (allowed values: OFF, INFO, WARNING, SEVERE).
 - ```powermonitor-path```: Full path to the power monitor program (only for Windows).
 - ```track-consumption-evolution```: generate .csv files for each method containing details of the method's consumption over the time. Each consumption value is mapped to an Unix timestamp.
-- ```evolution-data-path```: Path to the location where the consumption evolution csv files will be stored. The tool will attemp to create the folders if they do not alreay exists.
+- ```evolution-data-path```: path to the location where the consumption evolution csv files will be stored. The tool will attemp to create the folders if they do not alreay exists.
+- ```hide-agent-consumption```: if set to true, the energy consumption of the agent threads will not be reported.
 
 You can install the jar package (and the PowerMonitor.exe on Windows) wherever you want, and call it in the ```javaagent``` with the full path.
 However, ```config.properties``` must be copied to the same folder as where you run the Java command.

--- a/config.properties
+++ b/config.properties
@@ -33,11 +33,16 @@ logger-level=INFO
 
 # Method's consumption evolution tracking
 # Setting this option to true will generate CSV files with each method consumption evolution over the time
+# Allowed values: true, false
 track-consumption-evolution=true
 
-#If the option above in enabled, the generated CSV files will be stored at the given path
+# If the option above in enabled, the generated CSV files will be stored at the given path
 # Please escape slashes twice
 evolution-data-path=evolution
+
+# If enabled (true), the consumption of the methods related to any of the agent threads will not be reported.
+# Allowed values: true , false
+hide-agent-consumption=true
 
 # Path for our power monitor program on Windows
 # Please escape slashes twice

--- a/src/main/java/org/noureddine/joularjx/Agent.java
+++ b/src/main/java/org/noureddine/joularjx/Agent.java
@@ -31,8 +31,8 @@ import java.util.logging.Logger;
 
 public class Agent {
 
-    private static final String NAME_THREAD_NAME = "JoularJX Agent Thread";
-    private static final String COMPUTATION_THREAD_NAME = "JoularJX Agent Computation";
+    public static final String NAME_THREAD_NAME = "JoularJX Agent Thread";
+    public static final String COMPUTATION_THREAD_NAME = "JoularJX Agent Computation";
     private static final Logger logger = JoularJXLogging.getLogger();
 
     /**

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -1,6 +1,8 @@
 package org.noureddine.joularjx.monitor;
 
 import com.sun.management.OperatingSystemMXBean;
+
+import org.noureddine.joularjx.Agent;
 import org.noureddine.joularjx.cpu.Cpu;
 import org.noureddine.joularjx.result.ResultWriter;
 import org.noureddine.joularjx.utils.AgentProperties;
@@ -98,6 +100,12 @@ public class MonitoringHandler implements Runnable {
         try {
             for (int duration = 0; duration < SAMPLE_TIME_MILLISECONDS; duration += SAMPLE_RATE_MILLISECONDS) {
                 for (var entry : Thread.getAllStackTraces().entrySet()) {
+                    String threadName = entry.getKey().getName();
+                    //Ignoring agent related threads, if option is enabled
+                    if(this.properties.hideAgentConsumption() && (threadName.equals(Agent.COMPUTATION_THREAD_NAME) || threadName.equals(Agent.NAME_THREAD_NAME))){
+                        continue; //Ignoring the thread
+                    }
+
                     // Only check runnable threads (not waiting or blocked)
                     if (entry.getKey().getState() == Thread.State.RUNNABLE) {
                         var target = result.computeIfAbsent(entry.getKey(),

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -102,7 +102,7 @@ public class MonitoringHandler implements Runnable {
                 for (var entry : Thread.getAllStackTraces().entrySet()) {
                     String threadName = entry.getKey().getName();
                     //Ignoring agent related threads, if option is enabled
-                    if(this.properties.hideAgentConsumption() && (threadName.equals(Agent.COMPUTATION_THREAD_NAME) || threadName.equals(Agent.NAME_THREAD_NAME))){
+                    if(this.properties.hideAgentConsumption() && (threadName.equals(Agent.COMPUTATION_THREAD_NAME))) {
                         continue; //Ignoring the thread
                     }
 

--- a/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
@@ -108,6 +108,5 @@ public class ShutdownHandler implements Runnable {
                 resultWriter.write(methodEntry.getKey().toString(), methodEntry.getValue());
             }
         }
-        logger.log(Level.INFO, "Methods energy consumption evolution written to files.");
     }
 }

--- a/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
+++ b/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
@@ -36,6 +36,7 @@ public class AgentProperties {
     private static final String LOGGER_LEVEL_PROPERTY = "logger-level";
     private static final String TRACK_CONSUMPTION_EVOLUTION_PROPERTY = "track-consumption-evolution";
     private static final String EVOLUTION_DATA_PATH_PROPERTY = "evolution-data-path";
+    private static final String HIDE_AGENT_CONSUMPTION_PROPERTY = "hide-agent-consumption";
 
     /**
      * Loaded configuration properties
@@ -48,6 +49,7 @@ public class AgentProperties {
     private final Level loggerLevel;
     private final boolean consumptionEvolution;
     private final String evolutionDataPath;
+    private final boolean hideAgentConsumption;
 
     /**
      * Instantiate a new instance which will load the properties
@@ -61,6 +63,7 @@ public class AgentProperties {
         this.loggerLevel = loadLoggerLevel();
         this.consumptionEvolution = loadConsumptionEvolution();
         this.evolutionDataPath = loadEvolutionDataPath();
+        this.hideAgentConsumption = loadAgentConsumption();
     }
 
     public boolean filtersMethod(String methodName) {
@@ -94,6 +97,10 @@ public class AgentProperties {
 
     public String getEvolutionDataPath() {
         return this.evolutionDataPath;
+    }
+
+    public boolean hideAgentConsumption(){
+        return this.hideAgentConsumption;
     }
 
     private Properties loadProperties(FileSystem fileSystem) {
@@ -154,6 +161,10 @@ public class AgentProperties {
             return "evolution";
         }
         return property;
+    }
+
+    public boolean loadAgentConsumption() {
+        return Boolean.parseBoolean(properties.getProperty(HIDE_AGENT_CONSUMPTION_PROPERTY));
     }
 
     private Path getPropertiesPathIfExists(FileSystem fileSystem) {

--- a/src/test/java/org/noureddine/joularjx/utils/AgentPropertiesTest.java
+++ b/src/test/java/org/noureddine/joularjx/utils/AgentPropertiesTest.java
@@ -40,7 +40,8 @@ class AgentPropertiesTest {
                     () -> assertFalse(properties.savesRuntimeData()),
                     () -> assertEquals(Level.INFO, properties.getLoggerLevel()),
                     () -> assertFalse(properties.loadConsumptionEvolution()),
-                    () -> assertEquals("evolution", properties.loadEvolutionDataPath())
+                    () -> assertEquals("evolution", properties.loadEvolutionDataPath()),
+                    () -> assertFalse(properties.loadAgentConsumption())
             );
         }
     }
@@ -54,7 +55,8 @@ class AgentPropertiesTest {
                                 "save-runtime-data=true\n"+
                                 "overwrite-runtime-data=true\n"+
                                 "track-consumption-evolution=true\n"+
-                                "evolution-data-path="+path;
+                                "evolution-data-path="+path+"\n"+
+                                "hide-agent-consumption=true";
             Files.write(fs.getPath("config.properties"), (props).getBytes(StandardCharsets.UTF_8));
 
             AgentProperties properties = new AgentProperties(fs);
@@ -65,7 +67,8 @@ class AgentPropertiesTest {
                     () -> assertTrue(properties.savesRuntimeData()),
                     () -> assertTrue(properties.overwritesRuntimeData()),
                     () -> assertTrue(properties.trackConsumptionEvolution()),
-                    () -> assertEquals(path, properties.getEvolutionDataPath())
+                    () -> assertEquals(path, properties.getEvolutionDataPath()),
+                    () -> assertTrue(properties.hideAgentConsumption())
             );
         }
     }


### PR DESCRIPTION
The energy consumption of the agent's methods can now be hidden with a specific option in the configuration file.