### PR TITLE
Duplicate call tree fix

### DIFF
--- a/src/main/java/org/noureddine/joularjx/utils/CallTree.java
+++ b/src/main/java/org/noureddine/joularjx/utils/CallTree.java
@@ -79,7 +79,39 @@ public class CallTree {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((callTree == null) ? 0 : callTree.hashCode());
+        result = prime * result + ((this.callTree == null) ? 0 : hashCode(this.callTree));
+        
+        return result;
+    }
+
+    /**
+     * Custom implementation of the hashCode method for List of StackTraceElement.
+     * @param l the List<StackTraceElement> which hashCode will be computed.
+     * @return an int, the hashCode of the given List.
+     */
+    private int hashCode(List<StackTraceElement> l) {
+        int result = 1;
+        for (StackTraceElement element : l) {
+            result = 31 * result + hashCode(element);
+        }
+        
+        return result;
+    }
+
+    /**
+     * Custom implementation of the hashCode method for StackTraceElement.
+     * The hashCode is computed based on the class, the method and the file of the given element (if available).
+     * Custom hashCode does NOT take into account the line number.
+     * @param e the StackTraceElement which hashCode will be computed.
+     * @return an int, the hashCode for the given StackTraceElement.
+     */
+    private int hashCode(StackTraceElement e) {
+        int result = 31 * e.getClassName().hashCode() + e.getMethodName().hashCode();
+
+        if (e.getFileName() != null) {
+            result = 31 * result + e.getFileName().hashCode();
+        }
+
         return result;
     }
 
@@ -96,9 +128,57 @@ public class CallTree {
         if (callTree == null) {
             if (other.callTree != null)
                 return false;
-        } else if (!callTree.equals(other.callTree))
+        } else if (!equals(this.callTree, other.callTree))
             return false;
         return true;
+    }
+
+    /**
+     * Custom implementation of the equals method for call trees
+     * Two callTrees are equals if they contains the same elements in the same order
+     * @param callTree a List of StackTraceElement, representing a call tree
+     * @param other a List of StackTraceElement, representing a call tree
+     * @return a boolean, true if the two call trees are equals, false otherwise
+     */
+    private boolean equals(List<StackTraceElement> callTree, List<StackTraceElement> other) {
+        if (callTree == null ^ other == null) {
+            return false;
+        }
+
+        if (callTree == null && other == null) {
+            return true;
+        }
+
+        if (callTree.size() != other.size()) {
+            return false;
+        }
+
+        for (int i = 0; i < callTree.size(); i++) {
+            StackTraceElement e = callTree.get(i);
+            if (!equals(e, other.get(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Custom implementation of the equals method for StackTraceElement
+     * Two StackTraceElement are equals if they have the same file name (if available), class name and method name. 
+     * Please note that the line number is NOT checked, and if the three previous conditions are satisfied, two StackTraceElement with a different line number will be considered equals.
+     * @param e a StackTraceElement
+     * @param other a StackTraceElement
+     * @return a boolean, true if the two given StackTraceElement are equals, false otherwise
+     */
+    private boolean equals(StackTraceElement e, StackTraceElement other) {
+        boolean result = true;
+
+        if(e.getFileName() != null && other.getFileName() != null) {
+            result = result && e.getFileName().equals(other.getFileName());
+        }
+        
+        return result && e.getClassName().equals(other.getClassName()) && e.getMethodName().equals(other.getMethodName());
     }
     
 }

--- a/src/test/java/org/noureddine/joularjx/utils/CallTreeTest.java
+++ b/src/test/java/org/noureddine/joularjx/utils/CallTreeTest.java
@@ -65,6 +65,38 @@ public class CallTreeTest {
     }
 
     @Test
+    public void equalsWithSameElementsButNotSameLinesTest() {
+        StackTraceElement e = new StackTraceElement("ClassA", "MethodA", "FileA", 20);
+        StackTraceElement e1 = new StackTraceElement("ClassB", "MethodB", "FileB", 12);
+
+        StackTraceElement e2 = new StackTraceElement("ClassA", "MethodA", "FileA", 59);
+        StackTraceElement e3 = new StackTraceElement("ClassB", "MethodB", "FileB", 02);
+
+        StackTraceElement[] arr1 = {e, e1};
+        StackTraceElement[] arr2 = {e2, e3};
+
+        CallTree s1 = new CallTree(arr1);
+        CallTree s2 = new CallTree(arr2);
+
+        assertEquals(s1, s2);
+    }
+
+    @Test
+    public void equalsWithoutFileNameDoesNotFailsTest() {
+        StackTraceElement e = new StackTraceElement("ClassA", "MethodA", null, 20);
+        StackTraceElement e1 = new StackTraceElement("ClassB", "MethodB", null, 12);
+        StackTraceElement e2 = new StackTraceElement("ClassC", "MethodC", null, 59);
+
+        StackTraceElement[] arr1 = {e, e1, e2};
+        StackTraceElement[] arr2 = {e, e1, e2};
+
+        CallTree s1 = new CallTree(arr1);
+        CallTree s2 = new CallTree(arr2);
+
+        assertTrue(s1.equals(s2));
+    }
+
+    @Test
     public void toSringTest() {
         StackTraceElement e = new StackTraceElement("ClassA", "MethodA", "FileA", 20);
         StackTraceElement e1 = new StackTraceElement("ClassB", "MethodB", "FileB", 12);


### PR DESCRIPTION
Fixed the duplicate call trees bug by refactoring `equals` and `hashCode` methods of the CallTree class.