### PR TITLE
Added stack-monitoring-sample-rate to agent properties

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -60,6 +60,11 @@ save-call-trees-runtime-data=true
 # Allowed values: true, false
 overwrite-call-trees-runtime-data=true
 
+# The sample rate (milliseconds) for the agent to monitor the JVM call
+# stack. Lower means more accurate monitoring. Allowable values are
+# from 1 to 1000.
+stack-monitoring-sample-rate=10
+
 # Path for our power monitor program on Windows
 # On Windows, please escape slashes twice
 powermonitor-path=C:\\joularjx\\PowerMonitor.exe

--- a/install/config.properties
+++ b/install/config.properties
@@ -60,6 +60,11 @@ save-call-trees-runtime-data=true
 # Allowed values: true, false
 overwrite-call-trees-runtime-data=true
 
+# The sample rate (milliseconds) for the agent to monitor the JVM call
+# stack. Lower means more accurate monitoring. Allowable values are
+# from 1 to 1000.
+stack-monitoring-sample-rate=10
+
 # Path for our power monitor program on Windows
 # On Windows, please escape slashes twice
 powermonitor-path=C:\\joularjx\\PowerMonitor.exe

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -39,9 +39,6 @@ import com.sun.management.OperatingSystemMXBean;
 public class MonitoringHandler implements Runnable {
 
     private static final String DESTROY_THREAD_NAME = "DestroyJavaVM";
-    private static final long SAMPLE_TIME_MILLISECONDS = 1000;
-    private static final long SAMPLE_RATE_MILLISECONDS = 10;
-    private static final int SAMPLE_ITERATIONS = (int) (SAMPLE_TIME_MILLISECONDS / SAMPLE_RATE_MILLISECONDS);
     private static final Logger logger = JoularJXLogging.getLogger();
 
     private final long appPid;
@@ -52,6 +49,9 @@ public class MonitoringHandler implements Runnable {
     private final OperatingSystemMXBean osBean;
     private final ThreadMXBean threadBean;
     private final ResultTreeManager resultTreeManager;
+    private final long sampleTimeMilliseconds = 1000;
+    private final long sampleRateMilliseconds;
+    private final int sampleIterations;
 
     /**
      * Creates a new MonitoringHandler.
@@ -74,6 +74,8 @@ public class MonitoringHandler implements Runnable {
         this.osBean = osBean;
         this.threadBean = threadBean;
         this.resultTreeManager = resultTreeManager;
+        this.sampleRateMilliseconds = properties.stackMonitoringSampleRate();
+        this.sampleIterations = (int) (sampleTimeMilliseconds / sampleRateMilliseconds);
     }
 
     @Override
@@ -149,7 +151,7 @@ public class MonitoringHandler implements Runnable {
                     }
                 }
 
-                Thread.sleep(SAMPLE_RATE_MILLISECONDS);
+                Thread.sleep(sampleRateMilliseconds);
             } catch (InterruptedException exception) {
                 Thread.currentThread().interrupt();
             } catch (IOException exception) {
@@ -168,7 +170,7 @@ public class MonitoringHandler implements Runnable {
     private Map<Thread, List<StackTraceElement[]>> sample() {
         Map<Thread, List<StackTraceElement[]>> result = new HashMap<>();
         try {
-            for (int duration = 0; duration < SAMPLE_TIME_MILLISECONDS; duration += SAMPLE_RATE_MILLISECONDS) {
+            for (int duration = 0; duration < sampleTimeMilliseconds; duration += sampleRateMilliseconds) {
                 for (var entry : Thread.getAllStackTraces().entrySet()) {
                     String threadName = entry.getKey().getName();
                     //Ignoring agent related threads, if option is enabled
@@ -179,12 +181,12 @@ public class MonitoringHandler implements Runnable {
                     // Only check runnable threads (not waiting or blocked)
                     if (entry.getKey().getState() == Thread.State.RUNNABLE) {
                         var target = result.computeIfAbsent(entry.getKey(),
-                                t -> new ArrayList<>(SAMPLE_ITERATIONS));
+                                t -> new ArrayList<>(sampleIterations));
                         target.add(entry.getValue());
                     }
                 }
 
-                Thread.sleep(SAMPLE_RATE_MILLISECONDS);
+                Thread.sleep(sampleRateMilliseconds);
             }
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
@@ -256,7 +258,7 @@ public class MonitoringHandler implements Runnable {
         for (var entry : methodsStats.entrySet()) {
             long threadCpuTime = threadBean.getThreadCpuTime(entry.getKey().getId());
 
-            threadCpuTime *= entry.getValue().values().stream().mapToDouble(i -> i).sum() / SAMPLE_ITERATIONS;
+            threadCpuTime *= entry.getValue().values().stream().mapToDouble(i -> i).sum() / sampleIterations;
 
             // If thread already monitored, then calculate CPU time since last time
             threadCpuTime = threadsCpuTime.merge(entry.getKey().getId(), threadCpuTime,

--- a/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
+++ b/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
@@ -39,6 +39,7 @@ public class AgentProperties {
     private static final String CALL_TREES_CONSUMPTION_PROPERTY = "enable-call-trees-consumption";
     private static final String SAVE_CT_RUNTIME_DATA_PROPERTY = "save-call-trees-runtime-data";
     private static final String OVERWRITE_CT_RUNTIME_DATA_PROPERTY = "overwrite-call-trees-runtime-data";
+    private static final String STACK_MONITORING_SAMPLE_RATE_PROPERTY = "stack-monitoring-sample-rate";
 
     /**
      * Loaded configuration properties
@@ -55,6 +56,7 @@ public class AgentProperties {
     private final boolean callTreesConsumption;
     private final boolean saveCtRuntimeData;
     private final boolean overwriteCtRuntimeData;
+    private final int stackMonitoringSampleRate;
 
     /**
      * Instantiate a new instance which will load the properties
@@ -72,6 +74,7 @@ public class AgentProperties {
         this.callTreesConsumption = loadCallTreesConsumption();
         this.saveCtRuntimeData = loadSaveCallTreesRuntimeData();
         this.overwriteCtRuntimeData = loadOverwriteCallTreeRuntimeData();
+        this.stackMonitoringSampleRate = loadStackMonitoringSampleRate();
     }
 
     public boolean filtersMethod(String methodName) {
@@ -115,9 +118,9 @@ public class AgentProperties {
         return this.saveCtRuntimeData;
     }
 
-    public boolean overwriteCallTreesRuntimeData() {
-        return this.overwriteCtRuntimeData;
-    }
+    public boolean overwriteCallTreesRuntimeData() { return this.overwriteCtRuntimeData; }
+
+    public int stackMonitoringSampleRate() { return this.stackMonitoringSampleRate; }
 
     private Properties loadProperties(FileSystem fileSystem) {
         Properties result = new Properties();
@@ -184,6 +187,18 @@ public class AgentProperties {
 
     public boolean loadOverwriteCallTreeRuntimeData() {
         return Boolean.parseBoolean(properties.getProperty(OVERWRITE_CT_RUNTIME_DATA_PROPERTY));
+    }
+
+    public int loadStackMonitoringSampleRate() {
+        String property = properties.getProperty(STACK_MONITORING_SAMPLE_RATE_PROPERTY);
+        int value = 10; // default of 10 milliseconds
+        if(property != null) {
+            int parsedValue = Integer.parseInt(property);
+            if (parsedValue > 0 && parsedValue <= 1000) {
+                value = parsedValue;
+            }
+        }
+        return value;
     }
 
     private Path getPropertiesPathIfExists(FileSystem fileSystem) {

--- a/src/test/java/org/noureddine/joularjx/utils/AgentPropertiesTest.java
+++ b/src/test/java/org/noureddine/joularjx/utils/AgentPropertiesTest.java
@@ -53,7 +53,8 @@ class AgentPropertiesTest {
                     () -> assertFalse(properties.loadAgentConsumption()),
                     () -> assertFalse(properties.loadCallTreesConsumption()),
                     () -> assertFalse(properties.loadSaveCallTreesRuntimeData()),
-                    () -> assertFalse(properties.loadOverwriteCallTreeRuntimeData())
+                    () -> assertFalse(properties.loadOverwriteCallTreeRuntimeData()),
+                    () -> assertEquals(10, properties.loadStackMonitoringSampleRate())
             );
         }
     }
@@ -69,7 +70,8 @@ class AgentPropertiesTest {
                                 "hide-agent-consumption=true\n"+
                                 "enable-call-trees-consumption=true\n"+
                                 "save-call-trees-runtime-data=true\n"+
-                                "overwrite-call-trees-runtime-data=true";
+                                "overwrite-call-trees-runtime-data=true\n"+
+                                "stack-monitoring-sample-rate=1";
             Files.write(fs.getPath("config.properties"), (props).getBytes(StandardCharsets.UTF_8));
 
             AgentProperties properties = new AgentProperties(fs);
@@ -83,7 +85,8 @@ class AgentPropertiesTest {
                     () -> assertTrue(properties.hideAgentConsumption()),
                     () -> assertTrue(properties.callTreesConsumption()),
                     () -> assertTrue(properties.saveCallTreesRuntimeData()),
-                    () -> assertTrue(properties.overwriteCallTreesRuntimeData())
+                    () -> assertTrue(properties.overwriteCallTreesRuntimeData()),
+                    () -> assertEquals(1, properties.stackMonitoringSampleRate())
             );
         }
     }


### PR DESCRIPTION
Motivation for this PR: in some use cases it is preferable to have a more accurate JVM stack monitoring than the default 10 ms interval provides. Therefore this PR adds the `stack-monitoring-sample-rate` property so the sample rate/interval can be set by the user via config.properties. Allowable values are checked to be within [1,1000] range, defaulting to 10 ms when not set.