### PR TITLE
WIP: fix for energy consumptions values being infinite

### DIFF
--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -300,7 +300,10 @@ public class MonitoringHandler implements Runnable {
         for (var threadEntry : methodsStats.entrySet()) {
             double totalEncounters = threadEntry.getValue().values().stream().mapToDouble(i -> i).sum();
             for (var methodEntry : threadEntry.getValue().entrySet()) {
-                double methodPower = threadCpuTimePercentages.get(threadEntry.getKey().getId()) * (methodEntry.getValue() / totalEncounters);
+                double methodPower = 0.0;
+                if(totalEncounters >= Double.MIN_VALUE) {
+                    methodPower = threadCpuTimePercentages.get(threadEntry.getKey().getId()) * (methodEntry.getValue() / totalEncounters);
+                }
 
                 //Only of consumption evolution tracking is enabled
                 if (this.properties.trackConsumptionEvolution()) {
@@ -330,8 +333,11 @@ public class MonitoringHandler implements Runnable {
             double totalEncounters = entry.getValue().values().stream().mapToDouble(i -> i).sum();
 
             for (var callTreeEntry : entry.getValue().entrySet()) {
-                double stackTracePower = threadCpuTimePercentages.get(entry.getKey().getId()) * (callTreeEntry.getValue() / totalEncounters);
-                
+                double stackTracePower = 0.0;
+                if (totalEncounters >= Double.MIN_VALUE) {
+                     stackTracePower = threadCpuTimePercentages.get(entry.getKey().getId()) * (callTreeEntry.getValue() / totalEncounters);
+                }
+
                 callTreeConsumer.accept(callTreeEntry.getKey(), stackTracePower);
             }
         }


### PR DESCRIPTION
Occasionaly, the reported energy consumption values of methods or stacktraces are `Infinite`. This is caused by the `totalEncounters` variable being 0 in those cases. The root cause of that is unknown at this point. A WIP fix is to add guards that check against 0 values, and reporting 0.0 power consumption in those cases.

Perhaps there is a deeper cause to `totalEncounters` being 0, which does appear suspect given that the algorithm is iterating over defined key-value pairs.