### PR TITLE
Fix JoularJX not profiling applications correctly in applications servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ JoularJX can be configured by modifying the ```config.properties``` files:
 - ```enable-call-trees-consumption```: compute methods call trees energy consumption. A CSV file will be generated at the end of the agent's execution, associating to each call tree it's total energy consumption.
 - ```save-call-trees-runtime-data```: write runtime call trees power consumption in a CSV file. For each monitoring cycle (1 second), a new CSV file will be generated, containing the runtime power consumption of the call trees. The generated files will include timestamps in their names.
 - ```overwrite-call-trees-runtime-data```: overwrite runtime call trees power data file, or if set to false, it will write new file for each monitoring cycle.
+- ```application-server```: properly handles application servers and frameworks (Sprig Boot, Tomcat, etc.). Set ```true``` when running on application servers. If false, the monitoring loop will check if the JVM is destroyed, hence closing JoularJX when the application ends (in regular Java application). If true, JoularJX will continue to monitor correctly as the JVM isn't destroyed in a application server.
 
 You can install the jar package (and the PowerMonitor.exe on Windows) wherever you want, and call it in the ```javaagent``` with the full path.
 However, ```config.properties``` must be copied to the same folder as where you run the Java command.

--- a/config.properties
+++ b/config.properties
@@ -65,6 +65,12 @@ overwrite-call-trees-runtime-data=true
 # from 1 to 1000.
 stack-monitoring-sample-rate=10
 
+# If running the application on top of an application server or framework (spring, tomcat, etc.)
+# This changes how JoularJX loops when monitoring, using a while-true loop instead of a checking if the JVM is destroyed
+# On standard Java applications, the while-true loop don't quit when the application ends, hence why destroying the VM
+# Values: true, false
+application-server=false
+
 # Path for our power monitor program on Windows
 # On Windows, please escape slashes twice
 powermonitor-path=C:\\joularjx\\PowerMonitor.exe

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -395,7 +395,11 @@ public class MonitoringHandler implements Runnable {
      * @return true if the JVM destroying thread is present, false otherwise
      */
     private boolean destroyingVM() {
-        return Thread.getAllStackTraces().keySet().stream()
+        if (!this.properties.isApplicationServer()) {
+            return Thread.getAllStackTraces().keySet().stream()
                 .anyMatch(thread -> thread.getName().equals(DESTROY_THREAD_NAME));
+        } else {
+            return false;
+        }
     }
 }

--- a/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
+++ b/src/main/java/org/noureddine/joularjx/utils/AgentProperties.java
@@ -41,6 +41,7 @@ public class AgentProperties {
     private static final String SAVE_CT_RUNTIME_DATA_PROPERTY = "save-call-trees-runtime-data";
     private static final String OVERWRITE_CT_RUNTIME_DATA_PROPERTY = "overwrite-call-trees-runtime-data";
     private static final String STACK_MONITORING_SAMPLE_RATE_PROPERTY = "stack-monitoring-sample-rate";
+    private static final String APPLICATION_SERVER_PROPERTY = "application-server";
 
     /**
      * Loaded configuration properties
@@ -58,6 +59,7 @@ public class AgentProperties {
     private final boolean saveCtRuntimeData;
     private final boolean overwriteCtRuntimeData;
     private final int stackMonitoringSampleRate;
+    private final boolean applicationServer;
 
     /**
      * Instantiate a new instance which will load the properties
@@ -76,6 +78,7 @@ public class AgentProperties {
         this.saveCtRuntimeData = loadSaveCallTreesRuntimeData();
         this.overwriteCtRuntimeData = loadOverwriteCallTreeRuntimeData();
         this.stackMonitoringSampleRate = loadStackMonitoringSampleRate();
+        this.applicationServer = loadApplicationServer();
     }
 
     public AgentProperties() {
@@ -126,6 +129,8 @@ public class AgentProperties {
     public boolean overwriteCallTreesRuntimeData() { return this.overwriteCtRuntimeData; }
 
     public int stackMonitoringSampleRate() { return this.stackMonitoringSampleRate; }
+
+    public boolean isApplicationServer() { return this.applicationServer; }
 
     private Properties loadProperties(FileSystem fileSystem) {
         Properties result = new Properties();
@@ -193,6 +198,10 @@ public class AgentProperties {
 
     public boolean loadOverwriteCallTreeRuntimeData() {
         return Boolean.parseBoolean(properties.getProperty(OVERWRITE_CT_RUNTIME_DATA_PROPERTY));
+    }
+
+    public boolean loadApplicationServer() {
+        return Boolean.parseBoolean(properties.getProperty(APPLICATION_SERVER_PROPERTY));
     }
 
     public int loadStackMonitoringSampleRate() {


### PR DESCRIPTION
Add option to properly measure energy in JVM applications and for applications running in application servers.