### PR TITLE
Implement Service-Provider Interface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <maven.compiler.release>11</maven.compiler.release>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <auto-service.version>1.1.1</auto-service.version>
     </properties>
 
     <dependencies>
@@ -64,6 +65,11 @@
             <version>2.8.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service-annotations</artifactId>
+            <version>${auto-service.version}</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -86,6 +92,13 @@
                 <version>3.13.0</version>
                 <configuration>
                     <debug>true</debug>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>com.google.auto.service</groupId>
+                            <artifactId>auto-service</artifactId>
+                            <version>${auto-service.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/noureddine/joularjx/Agent.java
+++ b/src/main/java/org/noureddine/joularjx/Agent.java
@@ -75,7 +75,7 @@ public class Agent {
 		ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
 		// Check if CPU Time measurement is supported by the JVM. Quit otherwise
 		if (!threadBean.isThreadCpuTimeSupported()) {
-			logger.log(Level.SEVERE, "Thread CPU Time is not supported on this Java Virtual Machine. Existing...");
+			logger.log(Level.SEVERE, "Thread CPU Time is not supported on this Java Virtual Machine. Exiting...");
 			System.exit(1);
 		}
 
@@ -89,8 +89,8 @@ public class Agent {
 
 	/**
 	 * JVM hook to statically load the java agent at startup. After the Java Virtual
-	 * Machine (JVM) has initialized, the premain method will be called. Then the
-	 * real application main method will be called.
+	 * Machine (JVM) has initialized, the {@link #premain(String, Instrumentation)} method will be called. 
+	 * Then the real application {@code main} method will be called.
 	 */
 	public static void premain(String args, Instrumentation inst) {
 		Thread.currentThread().setName(NAME_THREAD_NAME);
@@ -107,7 +107,8 @@ public class Agent {
 		long appPid = ProcessHandle.current().pid();
 
 		// Creating the required folders to store the result files generated later on
-		ResultTreeManager resultTreeManager = new ResultTreeManager(properties, appPid, System.currentTimeMillis());
+		final long currentTime = System.currentTimeMillis();
+		ResultTreeManager resultTreeManager = new ResultTreeManager(properties, appPid, currentTime);
 		if (!resultTreeManager.create()) {
 			logger.log(Level.WARNING,
 					"Error(s) occurred while creating the result folder hierarchy. Some results may not be reported.");
@@ -117,11 +118,10 @@ public class Agent {
 
 		OperatingSystemMXBean osBean = createOperatingSystemBean(cpu);
 		MonitoringStatus status = new MonitoringStatus();
-		List<ResultWriter> resultWriters = providers();
+		List<ResultWriter> resultWriters = getWriters(properties, appPid, currentTime);
 		MonitoringHandler monitoringHandler = new MonitoringHandler(appPid, properties, resultWriters, cpu, status,
-				osBean, threadBean, resultTreeManager);
-		ShutdownHandler shutdownHandler = new ShutdownHandler(appPid, resultWriters, cpu, status, properties,
-				resultTreeManager);
+				osBean, threadBean);
+		ShutdownHandler shutdownHandler = new ShutdownHandler(appPid, resultWriters, cpu, status, properties);
 
 		logger.log(Level.INFO, "Initialization finished");
 
@@ -131,13 +131,19 @@ public class Agent {
 
 	/**
 	 * Get all output classes from SPI
+	 * @param props application properties
+	 * @param pid app PID
+	 * @param timestamp current timestamp
 	 *
-	 * @return the implementations to output data
+	 * @return the initialized implementations to output data
 	 */
-	public static List<ResultWriter> providers() {
+	public static List<ResultWriter> getWriters(AgentProperties props, long pid, long timestamp) {
 		List<ResultWriter> services = new ArrayList<>();
 		ServiceLoader<ResultWriter> loader = ServiceLoader.load(ResultWriter.class);
-		loader.forEach(services::add);
+		loader.forEach(service -> {
+			service.initialize(props, pid, timestamp);
+			services.add(service);
+		});
 		return services;
 	}
 

--- a/src/main/java/org/noureddine/joularjx/Agent.java
+++ b/src/main/java/org/noureddine/joularjx/Agent.java
@@ -11,118 +11,139 @@
 
 package org.noureddine.joularjx;
 
-import com.sun.management.OperatingSystemMXBean;
+import java.lang.instrument.Instrumentation;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import org.noureddine.joularjx.cpu.Cpu;
 import org.noureddine.joularjx.cpu.CpuFactory;
 import org.noureddine.joularjx.monitor.MonitoringHandler;
 import org.noureddine.joularjx.monitor.MonitoringStatus;
 import org.noureddine.joularjx.monitor.ShutdownHandler;
-import org.noureddine.joularjx.result.CsvResultWriter;
 import org.noureddine.joularjx.result.ResultTreeManager;
 import org.noureddine.joularjx.result.ResultWriter;
 import org.noureddine.joularjx.utils.AgentProperties;
 import org.noureddine.joularjx.utils.JoularJXLogging;
 
-import java.lang.instrument.Instrumentation;
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import com.sun.management.OperatingSystemMXBean;
 
 public class Agent {
 
-    public static final String NAME_THREAD_NAME = "JoularJX Agent Thread";
-    public static final String COMPUTATION_THREAD_NAME = "JoularJX Agent Computation";
-    private static final Logger logger = JoularJXLogging.getLogger();
+	public static final String NAME_THREAD_NAME = "JoularJX Agent Thread";
+	public static final String COMPUTATION_THREAD_NAME = "JoularJX Agent Computation";
+	private static final Logger logger = JoularJXLogging.getLogger();
 
-    /**
-     * JVM hook to statically load the java agent at startup.
-     * After the Java Virtual Machine (JVM) has initialized, the premain method
-     * will be called. Then the real application main method will be called.
-     */
-    public static void premain(String args, Instrumentation inst) {
-        Thread.currentThread().setName(NAME_THREAD_NAME);
-        AgentProperties properties = new AgentProperties();
-        JoularJXLogging.updateLevel(properties.getLoggerLevel());
+	/**
+	 * Creates and returns an OperatingSystemMXBean, used to collect CPU and process
+	 * loads.
+	 *
+	 * @param cpu a {@link Cpu} implementation
+	 * @return an OperatingSystemMXBean
+	 */
+	private static OperatingSystemMXBean createOperatingSystemBean(Cpu cpu) {
+		// Get OS MxBean to collect CPU and Process loads
+		OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
 
-        logger.info("+---------------------------------+");
-        logger.info("| JoularJX Agent Version 3.0.1    |");
-        logger.info("+---------------------------------+");
+		// Loop for a couple of seconds to initialize OSMXBean to get accurate details
+		// (first call will return -1)
+		logger.log(Level.INFO, "Please wait while initializing JoularJX...");
+		for (int i = 0; i < 2; i++) {
+			osBean.getSystemCpuLoad(); // In future when Java 17 becomes widely deployed, use getCpuLoad() instead
+			osBean.getProcessCpuLoad();
 
-        ThreadMXBean threadBean = createThreadBean();
+			cpu.initialize();
 
-        // Get Process ID of current application
-        long appPid = ProcessHandle.current().pid();
+			try {
+				Thread.sleep(500);
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		return osBean;
+	}
 
-        // Creating the required folders to store the result files generated later on
-        ResultTreeManager resultTreeManager = new ResultTreeManager(properties, appPid, System.currentTimeMillis());
-        if (!resultTreeManager.create()) {
-            logger.log(Level.WARNING, "Error(s) occurred while creating the result folder hierarchy. Some results may not be reported.");
-        }
+	/**
+	 * Creates and returns a ThreadMXBean. Checks if the Thread CPU Time is
+	 * supported by the JVM and enables it if it is disabled.
+	 */
+	private static ThreadMXBean createThreadBean() {
+		ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+		// Check if CPU Time measurement is supported by the JVM. Quit otherwise
+		if (!threadBean.isThreadCpuTimeSupported()) {
+			logger.log(Level.SEVERE, "Thread CPU Time is not supported on this Java Virtual Machine. Existing...");
+			System.exit(1);
+		}
 
-        Cpu cpu = CpuFactory.getCpu(properties);
+		// Enable CPU Time measurement if it is disabled
+		if (!threadBean.isThreadCpuTimeEnabled()) {
+			threadBean.setThreadCpuTimeEnabled(true);
+		}
 
-        OperatingSystemMXBean osBean = createOperatingSystemBean(cpu);
-        MonitoringStatus status = new MonitoringStatus();
-        ResultWriter resultWriter = new CsvResultWriter();
-        MonitoringHandler monitoringHandler = new MonitoringHandler(appPid, properties, resultWriter, cpu, status, osBean, threadBean, resultTreeManager);
-        ShutdownHandler shutdownHandler = new ShutdownHandler(appPid, resultWriter, cpu, status, properties, resultTreeManager);
+		return threadBean;
+	}
 
-        logger.log(Level.INFO, "Initialization finished");
+	/**
+	 * JVM hook to statically load the java agent at startup. After the Java Virtual
+	 * Machine (JVM) has initialized, the premain method will be called. Then the
+	 * real application main method will be called.
+	 */
+	public static void premain(String args, Instrumentation inst) {
+		Thread.currentThread().setName(NAME_THREAD_NAME);
+		AgentProperties properties = new AgentProperties();
+		JoularJXLogging.updateLevel(properties.getLoggerLevel());
 
-        new Thread(monitoringHandler, COMPUTATION_THREAD_NAME).start();
-        Runtime.getRuntime().addShutdownHook(new Thread(shutdownHandler));
-    }
+		logger.info("+---------------------------------+");
+		logger.info("| JoularJX Agent Version 3.0.1    |");
+		logger.info("+---------------------------------+");
 
-    /**
-     * Creates and returns a ThreadMXBean. 
-     * Checks if the Thread CPU Time is supported by the JVM and enables it if it is disabled.
-     */
-    private static ThreadMXBean createThreadBean() {
-        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
-        // Check if CPU Time measurement is supported by the JVM. Quit otherwise
-        if (!threadBean.isThreadCpuTimeSupported()) {
-            logger.log(Level.SEVERE, "Thread CPU Time is not supported on this Java Virtual Machine. Existing...");
-            System.exit(1);
-        }
+		ThreadMXBean threadBean = createThreadBean();
 
-        // Enable CPU Time measurement if it is disabled
-        if (!threadBean.isThreadCpuTimeEnabled()) {
-            threadBean.setThreadCpuTimeEnabled(true);
-        }
+		// Get Process ID of current application
+		long appPid = ProcessHandle.current().pid();
 
-        return threadBean;
-    }
+		// Creating the required folders to store the result files generated later on
+		ResultTreeManager resultTreeManager = new ResultTreeManager(properties, appPid, System.currentTimeMillis());
+		if (!resultTreeManager.create()) {
+			logger.log(Level.WARNING,
+					"Error(s) occurred while creating the result folder hierarchy. Some results may not be reported.");
+		}
 
-    /**
-     * Creates and returns an OperatingSystemMXBean, used to collect CPU and process loads.
-     * @param cpu a {@link Cpu} implementation
-     * @return an OperatingSystemMXBean
-     */
-    private static OperatingSystemMXBean createOperatingSystemBean(Cpu cpu) {
-        // Get OS MxBean to collect CPU and Process loads
-        OperatingSystemMXBean osBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
+		Cpu cpu = CpuFactory.getCpu(properties);
 
-        // Loop for a couple of seconds to initialize OSMXBean to get accurate details (first call will return -1)
-        logger.log(Level.INFO, "Please wait while initializing JoularJX...");
-        for (int i = 0; i < 2; i++) {
-            osBean.getSystemCpuLoad(); // In future when Java 17 becomes widely deployed, use getCpuLoad() instead
-            osBean.getProcessCpuLoad();
+		OperatingSystemMXBean osBean = createOperatingSystemBean(cpu);
+		MonitoringStatus status = new MonitoringStatus();
+		List<ResultWriter> resultWriters = providers();
+		MonitoringHandler monitoringHandler = new MonitoringHandler(appPid, properties, resultWriters, cpu, status,
+				osBean, threadBean, resultTreeManager);
+		ShutdownHandler shutdownHandler = new ShutdownHandler(appPid, resultWriters, cpu, status, properties,
+				resultTreeManager);
 
-            cpu.initialize();
+		logger.log(Level.INFO, "Initialization finished");
 
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException exception) {
-                Thread.currentThread().interrupt();
-            }
-        }
-        return osBean;
-    }
+		new Thread(monitoringHandler, COMPUTATION_THREAD_NAME).start();
+		Runtime.getRuntime().addShutdownHook(new Thread(shutdownHandler));
+	}
 
-    /**
-     * Private constructor
-     */
-    private Agent() {
-    }
+	/**
+	 * Get all output classes from SPI
+	 *
+	 * @return the implementations to output data
+	 */
+	public static List<ResultWriter> providers() {
+		List<ResultWriter> services = new ArrayList<>();
+		ServiceLoader<ResultWriter> loader = ServiceLoader.load(ResultWriter.class);
+		loader.forEach(services::add);
+		return services;
+	}
+
+	/**
+	 * Private constructor
+	 */
+	private Agent() {
+	}
 }

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -24,8 +24,9 @@ import java.util.logging.Logger;
 
 import org.noureddine.joularjx.Agent;
 import org.noureddine.joularjx.cpu.Cpu;
-import org.noureddine.joularjx.result.ResultTreeManager;
+import org.noureddine.joularjx.result.ResultScope;
 import org.noureddine.joularjx.result.ResultWriter;
+import org.noureddine.joularjx.result.ResultWriterConfiguration;
 import org.noureddine.joularjx.utils.AgentProperties;
 import org.noureddine.joularjx.utils.CallTree;
 import org.noureddine.joularjx.utils.JoularJXLogging;
@@ -50,7 +51,6 @@ public class MonitoringHandler implements Runnable {
 	private final MonitoringStatus status;
 	private final OperatingSystemMXBean osBean;
 	private final ThreadMXBean threadBean;
-	private final ResultTreeManager resultTreeManager;
 	private final long sampleTimeMilliseconds = 1000;
 	private final long sampleRateMilliseconds;
 	private final int sampleIterations;
@@ -58,21 +58,18 @@ public class MonitoringHandler implements Runnable {
 	/**
 	 * Creates a new MonitoringHandler.
 	 *
-	 * @param appPid            the PID of the monitored application
-	 * @param properties        the agent's configuration properties
-	 * @param resultWriters     the writers that will be used to save data in files
-	 * @param cpu               an implementation of the CPU interface, depending on
-	 *                          the OS and hardware
-	 * @param status            where all the runtime data will be saved
-	 * @param osBean            the OperatingSystemMXBean, used to collect CPU and
-	 *                          process loads
-	 * @param threadBean        the ThreadMXBean, used to collect thread CPU time
-	 * @param resultTreeManager the ResultTreeManager, used to provide filepaths for
-	 *                          runtime generated files
+	 * @param appPid        the PID of the monitored application
+	 * @param properties    the agent's configuration properties
+	 * @param resultWriters the writers that will be used to save data in files
+	 * @param cpu           an implementation of the CPU interface, depending on the
+	 *                      OS and hardware
+	 * @param status        where all the runtime data will be saved
+	 * @param osBean        the OperatingSystemMXBean, used to collect CPU and
+	 *                      process loads
+	 * @param threadBean    the ThreadMXBean, used to collect thread CPU time
 	 */
 	public MonitoringHandler(long appPid, AgentProperties properties, List<ResultWriter> resultWriters, Cpu cpu,
-			MonitoringStatus status, OperatingSystemMXBean osBean, ThreadMXBean threadBean,
-			ResultTreeManager resultTreeManager) {
+			MonitoringStatus status, OperatingSystemMXBean osBean, ThreadMXBean threadBean) {
 		this.appPid = appPid;
 		this.properties = properties;
 		this.resultWriters = resultWriters;
@@ -80,7 +77,6 @@ public class MonitoringHandler implements Runnable {
 		this.status = status;
 		this.osBean = osBean;
 		this.threadBean = threadBean;
-		this.resultTreeManager = resultTreeManager;
 		this.sampleRateMilliseconds = properties.stackMonitoringSampleRate();
 		this.sampleIterations = (int) (sampleTimeMilliseconds / sampleRateMilliseconds);
 	}
@@ -140,12 +136,13 @@ public class MonitoringHandler implements Runnable {
 	}
 
 	/**
-	 * Return the occurences of each method call during monitoring loop, per thread.
+	 * Return the occurrences of each method call during monitoring loop, per
+	 * thread.
 	 *
-	 * @param samples the result of the sampking step. A List of StackTraces of each
+	 * @param samples the result of the sampling step. A List of StackTraces of each
 	 *                Thread
 	 * @param covers  a Predicate, used to filter method names
-	 * @return for each Thread, a Map of each method and its occurences during the
+	 * @return for each Thread, a Map of each method and its occurrences during the
 	 *         last monitoring loop
 	 */
 	private Map<Thread, Map<String, Integer>> extractStats(Map<Thread, List<StackTraceElement[]>> samples,
@@ -294,43 +291,20 @@ public class MonitoringHandler implements Runnable {
 
 					// Writing runtime call trees power only if option is enabled
 					if (this.properties.saveCallTreesRuntimeData()) {
-						if (this.properties.overwriteCallTreesRuntimeData()) {
-							this.saveResults(callTreesStats, threadCpuTimePercentages,
-									this.resultTreeManager.getAllRuntimeCallTreePath()
-											+ String.format("/joularJX-%d-all-call-trees-power", appPid));
-							this.saveResults(filteredCallTreeStats, threadCpuTimePercentages,
-									this.resultTreeManager.getFilteredRuntimeCallTreePath()
-											+ String.format("/joularJX-%d-filtered-call-trees-power", appPid));
-						} else {
-							this.saveResults(callTreesStats, threadCpuTimePercentages,
-									this.resultTreeManager.getAllRuntimeCallTreePath()
-											+ String.format("/joularJX-%d-%d-all-call-trees-power", appPid,
-													System.currentTimeMillis()));
-							this.saveResults(filteredCallTreeStats, threadCpuTimePercentages,
-									this.resultTreeManager.getFilteredRuntimeCallTreePath()
-											+ String.format("/joularJX-%d-%d-filtered-call-trees-power", appPid,
-													System.currentTimeMillis()));
-						}
+						this.saveResults(callTreesStats, threadCpuTimePercentages, new ResultWriterConfiguration(
+								ResultScope.ALL_RUNTIME_CALL_TREE, !this.properties.overwriteCallTreesRuntimeData()));
+						this.saveResults(filteredCallTreeStats, threadCpuTimePercentages,
+								new ResultWriterConfiguration(ResultScope.FILTERED_RUNTIME_CALL_TREE,
+										!this.properties.overwriteCallTreesRuntimeData()));
 					}
 				}
 
 				// Writing runtime method's power only if option is enabled
 				if (this.properties.savesRuntimeData()) {
-					if (this.properties.overwritesRuntimeData()) {
-						this.saveResults(methodsStats, threadCpuTimePercentages,
-								this.resultTreeManager.getAllRuntimeMethodsPath()
-										+ String.format("/joularJX-%d-all-methods-power", appPid));
-						this.saveResults(methodsStatsFiltered, threadCpuTimePercentages,
-								this.resultTreeManager.getFilteredRuntimeMethodsPath()
-										+ String.format("/joularJX-%d-filtered-methods-power", appPid));
-					} else {
-						this.saveResults(methodsStats, threadCpuTimePercentages,
-								this.resultTreeManager.getAllRuntimeMethodsPath() + String.format(
-										"/joularJX-%d-%d-all-methods-power", appPid, System.currentTimeMillis()));
-						this.saveResults(methodsStatsFiltered, threadCpuTimePercentages,
-								this.resultTreeManager.getFilteredRuntimeMethodsPath() + String.format(
-										"/joularJX-%d-%d-filtered-methods-power", appPid, System.currentTimeMillis()));
-					}
+					this.saveResults(methodsStats, threadCpuTimePercentages, new ResultWriterConfiguration(
+							ResultScope.ALL_RUNTIME_METHODS, !this.properties.overwritesRuntimeData()));
+					this.saveResults(methodsStatsFiltered, threadCpuTimePercentages, new ResultWriterConfiguration(
+							ResultScope.FILTERED_RUNTIME_METHODS, !this.properties.overwritesRuntimeData()));
 				}
 
 				Thread.sleep(sampleRateMilliseconds);
@@ -379,23 +353,23 @@ public class MonitoringHandler implements Runnable {
 	}
 
 	/**
-	 * Writes the results in a file. The filename is partially defined by the given
+	 * Writes the results. The filename is partially defined by the given
 	 * parameters.
 	 *
 	 * @param <K>                      The type of key that will be written in the
-	 *                                 file. Must implement the toString() method.
+	 *                                 file. Must implement the {@code toString()}
+	 *                                 method.
 	 * @param stats                    the data to be written, given under the form
 	 *                                 of a Map<Thread, Map<K>, Double>> where the
 	 *                                 Double is the enrgy consumption.
 	 * @param threadCpuTimePercentages a map of CPU time usage per Thread (PID)
-	 * @param filePath                 the path of the file where the data will be
-	 *                                 written
+	 * @param config                   configuration for the writers
 	 * @throws IOException if an I/O error occurs while writing the file
 	 */
 	public <K> void saveResults(Map<Thread, Map<K, Integer>> stats, Map<Long, Double> threadCpuTimePercentages,
-			String filePath) throws IOException {
+			ResultWriterConfiguration config) throws IOException {
 		for (final ResultWriter resultWriter : resultWriters) {
-			resultWriter.setTarget(filePath, true);
+			resultWriter.setConfiguration(config);
 		}
 
 		for (var statEntry : stats.entrySet()) {
@@ -444,7 +418,7 @@ public class MonitoringHandler implements Runnable {
 	 * @param threadCpuTimePercentages   a map of CPU time usage per PID
 	 * @param updateMethodConsumedEnergy an object consumer, used to update all or
 	 *                                   only filtered methods
-	 * @param scope                      the scope (all methods or only filterd
+	 * @param scope                      the scope (all methods or only filtered
 	 *                                   methods). Used for energy consumption
 	 *                                   tracking
 	 */

--- a/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/MonitoringHandler.java
@@ -35,250 +35,161 @@ import org.noureddine.joularjx.utils.StackTraceFilter;
 import com.sun.management.OperatingSystemMXBean;
 
 /**
- * The MonitoringHandler performs all the sampling and energy computation step, and stores the data in dedicated MonitoringStatus structures or in files.
+ * The MonitoringHandler performs all the sampling and energy computation step,
+ * and stores the data in dedicated MonitoringStatus structures or in files.
  */
 public class MonitoringHandler implements Runnable {
 
-    private static final String DESTROY_THREAD_NAME = "DestroyJavaVM";
-    private static final Logger logger = JoularJXLogging.getLogger();
+	private static final String DESTROY_THREAD_NAME = "DestroyJavaVM";
+	private static final Logger logger = JoularJXLogging.getLogger();
 
-    private final long appPid;
-    private final AgentProperties properties;
-    private final ResultWriter resultWriter;
-    private final Cpu cpu;
-    private final MonitoringStatus status;
-    private final OperatingSystemMXBean osBean;
-    private final ThreadMXBean threadBean;
-    private final ResultTreeManager resultTreeManager;
-    private final long sampleTimeMilliseconds = 1000;
-    private final long sampleRateMilliseconds;
-    private final int sampleIterations;
-
-    /**
-     * Creates a new MonitoringHandler.
-     * @param appPid the PID of the monitored application
-     * @param properties the agent's configuration properties
-     * @param resultWriter the writer that will be used to save data in files
-     * @param cpu an implementation of the CPU interface, depending on the OS and hardware
-     * @param status where all the runtime data will be saved
-     * @param osBean the OperatingSystemMXBean, used to collect CPU and process loads
-     * @param threadBean the ThreadMXBean, used to collect thread CPU time
-     * @param resultTreeManager the ResultTreeManager, used to provide filepaths for runtime generated files
-     */
-    public MonitoringHandler(long appPid, AgentProperties properties, ResultWriter resultWriter, Cpu cpu,
-                             MonitoringStatus status, OperatingSystemMXBean osBean, ThreadMXBean threadBean, ResultTreeManager resultTreeManager) {
-        this.appPid = appPid;
-        this.properties = properties;
-        this.resultWriter = resultWriter;
-        this.cpu = cpu;
-        this.status = status;
-        this.osBean = osBean;
-        this.threadBean = threadBean;
-        this.resultTreeManager = resultTreeManager;
-        this.sampleRateMilliseconds = properties.stackMonitoringSampleRate();
-        this.sampleIterations = (int) (sampleTimeMilliseconds / sampleRateMilliseconds);
-    }
-
-    @Override
-    public void run() {
-        logger.log(Level.INFO, String.format("Started monitoring application with ID %d", appPid));
-
-        // CPU time for each thread
-        Map<Long, Long> threadsCpuTime = new HashMap<>();
-
-        while (!destroyingVM()) {
-            try {
-                double energyBefore = cpu.getInitialPower();
-
-                var samples = sample();
-                var methodsStats = extractStats(samples, methodName -> true);
-                var methodsStatsFiltered = extractStats(samples, properties::filtersMethod);
-
-                //Collecting call trees stats only if the option is enabled
-                Map<Thread, Map<CallTree, Integer>> callTreesStats = null;
-                Map<Thread, Map<CallTree, Integer>> filteredCallTreeStats = null;
-                if (this.properties.callTreesConsumption()) {
-                    callTreesStats = extractCallTreesStats(samples, methodName -> true);
-                    filteredCallTreeStats = extractCallTreesStats(samples, properties::filtersMethod);
-                }
-
-                double cpuLoad = osBean.getSystemCpuLoad(); // In future when Java 17 becomes widely deployed, use getCpuLoad() instead
-                double processCpuLoad = osBean.getProcessCpuLoad();
-
-                double energyAfter = cpu.getCurrentPower(cpuLoad);
-                double cpuEnergy = energyAfter - energyBefore;
-                
-                // Check if energy after is smaller than before
-                // Meaning: RAPL energy has wrapped
-                if (energyBefore > energyAfter) {
-                    cpuEnergy += cpu.getMaxPower(cpuLoad);
-                }
-
-                // if cpuEnergy is negative, skip this cycle.
-                // this happens when energy counter is reset during program execution
-                if (cpuEnergy < 0) {
-                	logger.info("Negative energy delta detected, skipping this cycle: " + cpuEnergy);
-                	continue;
-                }
-                
-                // Calculate CPU energy consumption of the process of the JVM all its apps
-                double processEnergy = calculateProcessCpuEnergy(cpuLoad, processCpuLoad, cpuEnergy);
-
-                // Adds current power to total energy
-                status.addConsumedEnergy(processEnergy);
-
-                // Now we have:
-                // CPU energy for JVM process
-                // CPU energy for all processes
-                // We need to calculate energy for each thread
-//                long totalThreadsCpuTime = updateThreadsCpuTime(methodsStats, threadsCpuTime);
-//                var threadCpuTimePercentages = getThreadsCpuTimePercentage(threadsCpuTime, totalThreadsCpuTime, processEnergy);
-
-                var threadCpuTimePercentages = getThreadsCpuTimePercentage(methodsStats, threadsCpuTime, processEnergy);
-                
-                updateMethodsConsumedEnergy(methodsStats, threadCpuTimePercentages, status::addMethodConsumedEnergy, Scope.ALL);
-                updateMethodsConsumedEnergy(methodsStatsFiltered, threadCpuTimePercentages, status::addFilteredMethodConsumedEnergy, Scope.FILTERED);
-
-                //Updating call trees consumption if option is enabled
-                if (this.properties.callTreesConsumption()) {
-                    updateCallTreesConsumedEnergy(callTreesStats, threadCpuTimePercentages, status::addCallTreeConsumedEnergy);
-                    updateCallTreesConsumedEnergy(filteredCallTreeStats, threadCpuTimePercentages, status::addFilteredCallTreeConsumedEnergy);
-
-                    //Writing runtime call trees power only if option is enabled
-                    if (this.properties.saveCallTreesRuntimeData()) {
-                        if (this.properties.overwriteCallTreesRuntimeData()) {
-                            this.saveResults(callTreesStats, threadCpuTimePercentages, this.resultTreeManager.getAllRuntimeCallTreePath()+String.format("/joularJX-%d-all-call-trees-power", appPid));
-                            this.saveResults(filteredCallTreeStats, threadCpuTimePercentages, this.resultTreeManager.getFilteredRuntimeCallTreePath()+String.format("/joularJX-%d-filtered-call-trees-power", appPid));
-                        } else {
-                            this.saveResults(callTreesStats, threadCpuTimePercentages, this.resultTreeManager.getAllRuntimeCallTreePath()+String.format("/joularJX-%d-%d-all-call-trees-power", appPid, System.currentTimeMillis()));
-                            this.saveResults(filteredCallTreeStats, threadCpuTimePercentages, this.resultTreeManager.getFilteredRuntimeCallTreePath()+String.format("/joularJX-%d-%d-filtered-call-trees-power", appPid, System.currentTimeMillis()));
-                        }
-                    }
-                }
-
-                //Writing runtime method's power only if option is enabled
-                if (this.properties.savesRuntimeData()) {
-                    if (this.properties.overwritesRuntimeData()) {
-                        this.saveResults(methodsStats, threadCpuTimePercentages, this.resultTreeManager.getAllRuntimeMethodsPath()+String.format("/joularJX-%d-all-methods-power", appPid));
-                        this.saveResults(methodsStatsFiltered, threadCpuTimePercentages, this.resultTreeManager.getFilteredRuntimeMethodsPath()+String.format("/joularJX-%d-filtered-methods-power", appPid));
-                    } else {
-                        this.saveResults(methodsStats, threadCpuTimePercentages, this.resultTreeManager.getAllRuntimeMethodsPath()+String.format("/joularJX-%d-%d-all-methods-power", appPid, System.currentTimeMillis()));
-                        this.saveResults(methodsStatsFiltered, threadCpuTimePercentages, this.resultTreeManager.getFilteredRuntimeMethodsPath()+String.format("/joularJX-%d-%d-filtered-methods-power", appPid, System.currentTimeMillis()));
-                    }
-                }
-
-                Thread.sleep(sampleRateMilliseconds);
-            } catch (InterruptedException exception) {
-                Thread.currentThread().interrupt();
-            } catch (IOException exception) {
-                logger.log(Level.SEVERE, "Cannot perform IO \"{0}\"", exception.getMessage());
-                logger.throwing(getClass().getName(), "run", exception);
-                System.exit(1);
-            }
-        }
-    }
+	private final long appPid;
+	private final AgentProperties properties;
+	private final List<ResultWriter> resultWriters;
+	private final Cpu cpu;
+	private final MonitoringStatus status;
+	private final OperatingSystemMXBean osBean;
+	private final ThreadMXBean threadBean;
+	private final ResultTreeManager resultTreeManager;
+	private final long sampleTimeMilliseconds = 1000;
+	private final long sampleRateMilliseconds;
+	private final int sampleIterations;
 
 	/**
-     * Performs the sampling step. Collects a set of stack traces for each thread.
-     * The sampling step is performed multiple time at the frequecy of SAMPLE_RATE_MILLSECONDS, for the duration of SAMPLE_TIME_MILLISECONDS
-     * @return for each Thread, a List of it's the stack traces
-     */
-    private Map<Thread, List<StackTraceElement[]>> sample() {
-        Map<Thread, List<StackTraceElement[]>> result = new HashMap<>();
-        try {
-            for (int duration = 0; duration < sampleTimeMilliseconds; duration += sampleRateMilliseconds) {
-                for (var entry : Thread.getAllStackTraces().entrySet()) {
-                    String threadName = entry.getKey().getName();
-                    //Ignoring agent related threads, if option is enabled
-                    if(this.properties.hideAgentConsumption() && (threadName.equals(Agent.COMPUTATION_THREAD_NAME))) {
-                        continue; //Ignoring the thread
-                    }
+	 * Creates a new MonitoringHandler.
+	 *
+	 * @param appPid            the PID of the monitored application
+	 * @param properties        the agent's configuration properties
+	 * @param resultWriters     the writers that will be used to save data in files
+	 * @param cpu               an implementation of the CPU interface, depending on
+	 *                          the OS and hardware
+	 * @param status            where all the runtime data will be saved
+	 * @param osBean            the OperatingSystemMXBean, used to collect CPU and
+	 *                          process loads
+	 * @param threadBean        the ThreadMXBean, used to collect thread CPU time
+	 * @param resultTreeManager the ResultTreeManager, used to provide filepaths for
+	 *                          runtime generated files
+	 */
+	public MonitoringHandler(long appPid, AgentProperties properties, List<ResultWriter> resultWriters, Cpu cpu,
+			MonitoringStatus status, OperatingSystemMXBean osBean, ThreadMXBean threadBean,
+			ResultTreeManager resultTreeManager) {
+		this.appPid = appPid;
+		this.properties = properties;
+		this.resultWriters = resultWriters;
+		this.cpu = cpu;
+		this.status = status;
+		this.osBean = osBean;
+		this.threadBean = threadBean;
+		this.resultTreeManager = resultTreeManager;
+		this.sampleRateMilliseconds = properties.stackMonitoringSampleRate();
+		this.sampleIterations = (int) (sampleTimeMilliseconds / sampleRateMilliseconds);
+	}
 
-                    // Only check runnable threads (not waiting or blocked)
-                    if (entry.getKey().getState() == Thread.State.RUNNABLE) {
-                        var target = result.computeIfAbsent(entry.getKey(),
-                                t -> new ArrayList<>(sampleIterations));
-                        target.add(entry.getValue());
-                    }
-                }
+	/**
+	 * Calculate process energy consumption
+	 *
+	 * @param totalCpuUsage   Total CPU usage
+	 * @param processCpuUsage Process CPU usage
+	 * @param cpuEnergy       CPU energy
+	 * @return Process energy consumption
+	 */
+	private double calculateProcessCpuEnergy(double totalCpuUsage, double processCpuUsage, double cpuEnergy) {
+		return (processCpuUsage * cpuEnergy) / totalCpuUsage;
+	}
 
-                Thread.sleep(sampleRateMilliseconds);
-            }
-        } catch (InterruptedException exception) {
-            Thread.currentThread().interrupt();
-        }
+	/**
+	 * Indicate if the JVM is destroying
+	 *
+	 * @return true if the JVM destroying thread is present, false otherwise
+	 */
+	private boolean destroyingVM() {
+		if (!this.properties.isApplicationServer()) {
+			return Thread.getAllStackTraces().keySet().stream()
+					.anyMatch(thread -> thread.getName().equals(DESTROY_THREAD_NAME));
+		} else {
+			return false;
+		}
+	}
 
-        return result;
-    }
+	/**
+	 * Returns the occurences of each call tree during monitoring loop, per thread.
+	 *
+	 * @param samples the result of the sampling step. A List of StackTraces of each
+	 *                Thread.
+	 * @param filter  a Predicate, used to filter method names within the call tree.
+	 * @return for each Thread, a Map of each CallTree and its occurences during the
+	 *         last monitoring loop.
+	 */
+	private Map<Thread, Map<CallTree, Integer>> extractCallTreesStats(Map<Thread, List<StackTraceElement[]>> samples,
+			Predicate<String> filter) {
+		Map<Thread, Map<CallTree, Integer>> stats = new HashMap<>();
 
-    /**
-     * Return the occurences of each method call during monitoring loop, per thread.
-     * @param samples the result of the sampking step. A List of StackTraces of each Thread
-     * @param covers a Predicate, used to filter method names
-     * @return for each Thread, a Map of each method and its occurences during the last monitoring loop
-     */
-    private Map<Thread, Map<String, Integer>> extractStats(Map<Thread, List<StackTraceElement[]>> samples,
-                                                           Predicate<String> covers) {
-        Map<Thread, Map<String, Integer>> stats = new HashMap<>();
+		for (var entry : samples.entrySet()) {
+			Map<CallTree, Integer> target = new HashMap<>();
+			stats.put(entry.getKey(), target);
 
-        for (var entry : samples.entrySet()) {
-            Map<String, Integer> target = new HashMap<>();
-            stats.put(entry.getKey(), target);
+			for (var stackTraceEntry : entry.getValue()) {
+				List<StackTraceElement> stackTrace = StackTraceFilter.filter(stackTraceEntry, filter);
+				if (!stackTrace.isEmpty()) {
+					target.merge(new CallTree(stackTrace), 1, Integer::sum);
+				}
+			}
+		}
 
-            for (StackTraceElement[] stackTrace : entry.getValue()) {
-                for (StackTraceElement stackTraceElement : stackTrace) {
-                    String methodName = stackTraceElement.getClassName() + "." + stackTraceElement.getMethodName();
-                    if (covers.test(methodName)) {
-                        target.merge(methodName, 1, Integer::sum);
-                        break;
-                    }
-                }
-            }
-        }
+		return stats;
+	}
 
-        return stats;
-    }
+	/**
+	 * Return the occurences of each method call during monitoring loop, per thread.
+	 *
+	 * @param samples the result of the sampking step. A List of StackTraces of each
+	 *                Thread
+	 * @param covers  a Predicate, used to filter method names
+	 * @return for each Thread, a Map of each method and its occurences during the
+	 *         last monitoring loop
+	 */
+	private Map<Thread, Map<String, Integer>> extractStats(Map<Thread, List<StackTraceElement[]>> samples,
+			Predicate<String> covers) {
+		Map<Thread, Map<String, Integer>> stats = new HashMap<>();
 
-    /**
-     * Returns the occurences of each call tree during monitoring loop, per thread.
-     * @param samples the result of the sampling step. A List of StackTraces of each Thread. 
-     * @param filter a Predicate, used to filter method names within the call tree.
-     * @return for each Thread, a Map of each CallTree and its occurences during the last monitoring loop.
-     */
-    private Map<Thread, Map<CallTree, Integer>> extractCallTreesStats(Map<Thread, List<StackTraceElement[]>> samples, Predicate<String> filter){
-        Map<Thread, Map<CallTree, Integer>> stats = new HashMap<>();
+		for (var entry : samples.entrySet()) {
+			Map<String, Integer> target = new HashMap<>();
+			stats.put(entry.getKey(), target);
 
-        for (var entry : samples.entrySet()) {
-            Map<CallTree, Integer> target = new HashMap<>();
-            stats.put(entry.getKey(), target);
+			for (StackTraceElement[] stackTrace : entry.getValue()) {
+				for (StackTraceElement stackTraceElement : stackTrace) {
+					String methodName = stackTraceElement.getClassName() + "." + stackTraceElement.getMethodName();
+					if (covers.test(methodName)) {
+						target.merge(methodName, 1, Integer::sum);
+						break;
+					}
+				}
+			}
+		}
 
-            for (var stackTraceEntry : entry.getValue()) {
-                List<StackTraceElement> stackTrace = StackTraceFilter.filter(stackTraceEntry, filter);
-                if (!stackTrace.isEmpty()) {
-                    target.merge(new CallTree(stackTrace), 1, Integer::sum);
-                }
-            }
-        }
+		return stats;
+	}
 
-        return stats;
-    }
-
-    
-    /**
-     * Updates the CPU times for each Thread.
-     * Returns for each thread (PID) it's percentage of CPU time used
-     * @param methodsStats a map of method occurrences for each thread
-     * @param threadsCpuTime a map of CPU time per PID, contains the cpu time for each tread, resulting from the last call to getThreadCpuTime(threadId)
-     * @param processEnergy the energy consumed by the process in the last monitoring period
-     * @return for each PID, the percentage of energy used by the associated thread
-     */
-    private Map<Long, Double> getThreadsCpuTimePercentage(Map<Thread, Map<String, Integer>> methodsStats,
+	/**
+	 * Updates the CPU times for each Thread. Returns for each thread (PID) it's
+	 * percentage of CPU time used
+	 *
+	 * @param methodsStats   a map of method occurrences for each thread
+	 * @param threadsCpuTime a map of CPU time per PID, contains the cpu time for
+	 *                       each tread, resulting from the last call to
+	 *                       getThreadCpuTime(threadId)
+	 * @param processEnergy  the energy consumed by the process in the last
+	 *                       monitoring period
+	 * @return for each PID, the percentage of energy used by the associated thread
+	 */
+	private Map<Long, Double> getThreadsCpuTimePercentage(Map<Thread, Map<String, Integer>> methodsStats,
 			Map<Long, Long> threadsCpuTime, double processEnergy) {
-		Map<Long, Double> threadsCpuTimePercentage = new HashMap<Long, Double>();
-    	
-		Map<Long, Double> actualThreadsCpuTime = new HashMap<Long, Double>(); 
+		Map<Long, Double> threadsCpuTimePercentage = new HashMap<>();
+
+		Map<Long, Double> actualThreadsCpuTime = new HashMap<>();
 		double totalThreadsCpuTime = 0;
-		// first compute the proportion of cpu time for each thread in the last sampling period
+		// first compute the proportion of cpu time for each thread in the last sampling
+		// period
 		for (Entry<Thread, Map<String, Integer>> threadEntry : methodsStats.entrySet()) {
 			long threadId = threadEntry.getKey().getId();
 			long currentThreadCpuTime = threadBean.getThreadCpuTime(threadId);
@@ -286,125 +197,283 @@ public class MonitoringHandler implements Runnable {
 			if (currentThreadCpuTime < 0) { // thread has quit
 				// TODO ignore last sampling period??
 				long jump = this.sampleRateMilliseconds / 10;
-				currentThreadCpuTime = previousThreadCpuTime + jump; // assume interval of 1 millisecond 
-				logger.info("Thread CPU time negative, taking previous time + " + jump + " : " + currentThreadCpuTime + " for thread: " + threadId);
+				currentThreadCpuTime = previousThreadCpuTime + jump; // assume interval of 1 millisecond
+				logger.info("Thread CPU time negative, taking previous time + " + jump + " : " + currentThreadCpuTime
+						+ " for thread: " + threadId);
 			}
-			
+
 			threadsCpuTime.put(threadId, currentThreadCpuTime);
 			long delta = currentThreadCpuTime - previousThreadCpuTime;
-			double adjustedThreadCpuTime = delta * threadEntry.getValue().values().stream().mapToDouble(i -> i).sum() / sampleIterations;
+			double adjustedThreadCpuTime = delta * threadEntry.getValue().values().stream().mapToDouble(i -> i).sum()
+					/ sampleIterations;
 			totalThreadsCpuTime += adjustedThreadCpuTime;
 			actualThreadsCpuTime.put(threadId, adjustedThreadCpuTime);
 		}
-		
-		// compute the proportion of total energy consumed by the thread using its proportion of cpu time in the last sampling period
-    	for (Entry<Long, Double> threadEntry : actualThreadsCpuTime.entrySet()) {
-    		double threadEnergy = totalThreadsCpuTime > 0d?threadEntry.getValue() * processEnergy / totalThreadsCpuTime : 0d;
-    		threadsCpuTimePercentage.put(threadEntry.getKey(), threadEnergy);
-    	}
-		
+
+		// compute the proportion of total energy consumed by the thread using its
+		// proportion of cpu time in the last sampling period
+		for (Entry<Long, Double> threadEntry : actualThreadsCpuTime.entrySet()) {
+			double threadEnergy = totalThreadsCpuTime > 0d
+					? threadEntry.getValue() * processEnergy / totalThreadsCpuTime
+					: 0d;
+			threadsCpuTimePercentage.put(threadEntry.getKey(), threadEnergy);
+		}
+
 		return threadsCpuTimePercentage;
 	}
-    
-    /**
-     * Update method's consumed energy. 
-     * @param methodsStats method's encounters statistics per Thread
-     * @param threadCpuTimePercentages a map of CPU time usage per PID
-     * @param updateMethodConsumedEnergy an object consumer, used to update all or only filtered methods
-     * @param scope the scope (all methods or only filterd methods). Used for energy consumption tracking
-     */
-    private void updateMethodsConsumedEnergy(Map<Thread, Map<String, Integer>> methodsStats,
-                                             Map<Long, Double> threadCpuTimePercentages,
-                                             ObjDoubleConsumer<String> updateMethodConsumedEnergy,
-                                             Scope scope) {
-        for (var threadEntry : methodsStats.entrySet()) {
-            double totalEncounters = threadEntry.getValue().values().stream().mapToDouble(i -> i).sum();
-            for (var methodEntry : threadEntry.getValue().entrySet()) {
-                double methodPower = 0.0;
-                if(totalEncounters >= Double.MIN_VALUE) {
-                    methodPower = threadCpuTimePercentages.get(threadEntry.getKey().getId()) * (methodEntry.getValue() / totalEncounters);
-                }
 
-                //Only of consumption evolution tracking is enabled
-                if (this.properties.trackConsumptionEvolution()) {
-                    //computing the UNIX EPOCH timestamp
-                    long unixTimestamp = System.currentTimeMillis() / 1000L;
+	@Override
+	public void run() {
+		logger.log(Level.INFO, String.format("Started monitoring application with ID %d", appPid));
 
-                    if (scope == Scope.ALL) {
-                        this.status.trackMethodConsumption(methodEntry.getKey(), unixTimestamp, methodPower);
-                    } else {
-                        this.status.trackFilteredMethodConsumption(methodEntry.getKey(), unixTimestamp, methodPower);
-                    }
-                }
+		// CPU time for each thread
+		Map<Long, Long> threadsCpuTime = new HashMap<>();
 
-                updateMethodConsumedEnergy.accept(methodEntry.getKey(), methodPower);
-            }
-        }
-    }
+		while (!destroyingVM()) {
+			try {
+				double energyBefore = cpu.getInitialPower();
 
-    /**
-     * Update call trees consumed energy.
-     * @param stats call trees encounters statistics per Thread
-     * @param threadCpuTimePercentages map of CPU time usage per PID
-     * @param callTreeConsumer the method used to update the energy consumption
-     */
-    private void updateCallTreesConsumedEnergy(Map<Thread, Map<CallTree, Integer>> stats, Map<Long, Double> threadCpuTimePercentages, ObjDoubleConsumer<CallTree> callTreeConsumer) {
-        for (var entry : stats.entrySet()) {
-            double totalEncounters = entry.getValue().values().stream().mapToDouble(i -> i).sum();
+				var samples = sample();
+				var methodsStats = extractStats(samples, methodName -> true);
+				var methodsStatsFiltered = extractStats(samples, properties::filtersMethod);
 
-            for (var callTreeEntry : entry.getValue().entrySet()) {
-                double stackTracePower = 0.0;
-                if (totalEncounters >= Double.MIN_VALUE) {
-                     stackTracePower = threadCpuTimePercentages.get(entry.getKey().getId()) * (callTreeEntry.getValue() / totalEncounters);
-                }
+				// Collecting call trees stats only if the option is enabled
+				Map<Thread, Map<CallTree, Integer>> callTreesStats = null;
+				Map<Thread, Map<CallTree, Integer>> filteredCallTreeStats = null;
+				if (this.properties.callTreesConsumption()) {
+					callTreesStats = extractCallTreesStats(samples, methodName -> true);
+					filteredCallTreeStats = extractCallTreesStats(samples, properties::filtersMethod);
+				}
 
-                callTreeConsumer.accept(callTreeEntry.getKey(), stackTracePower);
-            }
-        }
-    }
+				double cpuLoad = osBean.getSystemCpuLoad(); // In future when Java 17 becomes widely deployed, use
+															// getCpuLoad() instead
+				double processCpuLoad = osBean.getProcessCpuLoad();
 
-    /**
-     * Calculate process energy consumption
-     * @param totalCpuUsage Total CPU usage
-     * @param processCpuUsage Process CPU usage
-     * @param cpuEnergy CPU energy
-     * @return Process energy consumption
-     */
-    private double calculateProcessCpuEnergy(double totalCpuUsage, double processCpuUsage, double cpuEnergy) {
-        return (processCpuUsage * cpuEnergy) / totalCpuUsage;
-    }
+				double energyAfter = cpu.getCurrentPower(cpuLoad);
+				double cpuEnergy = energyAfter - energyBefore;
 
-    /**
-     * Writes the results in a file. The filename is partially defined by the given parameters.
-     * @param <K> The type of key that will be written in the file. Must implement the toString() method.
-     * @param stats the data to be written, given under the form of a Map<Thread, Map<K>, Double>> where the Double is the enrgy consumption.
-     * @param threadCpuTimePercentages a map of CPU time usage per Thread (PID)
-     * @param filePath the path of the file where the data will be written
-     * @throws IOException if an I/O error occurs while writing the file
-     */
-    public <K> void saveResults(Map<Thread, Map<K,Integer>> stats,  Map<Long, Double> threadCpuTimePercentages, String filePath) throws IOException {
-        resultWriter.setTarget(filePath, true);
+				// Check if energy after is smaller than before
+				// Meaning: RAPL energy has wrapped
+				if (energyBefore > energyAfter) {
+					cpuEnergy += cpu.getMaxPower(cpuLoad);
+				}
 
-            for (var statEntry : stats.entrySet()) {
-                for (var entry : statEntry.getValue().entrySet()) {
-                    double power = threadCpuTimePercentages.get(statEntry.getKey().getId()) * (entry.getValue() / 100.0);
-                    resultWriter.write(entry.getKey().toString(), power);
-                }
-            }
-        
-            resultWriter.closeTarget();
-    }
+				// if cpuEnergy is negative, skip this cycle.
+				// this happens when energy counter is reset during program execution
+				if (cpuEnergy < 0) {
+					logger.info("Negative energy delta detected, skipping this cycle: " + cpuEnergy);
+					continue;
+				}
 
-    /**
-     * Indicate if the JVM is destroying
-     * @return true if the JVM destroying thread is present, false otherwise
-     */
-    private boolean destroyingVM() {
-        if (!this.properties.isApplicationServer()) {
-            return Thread.getAllStackTraces().keySet().stream()
-                .anyMatch(thread -> thread.getName().equals(DESTROY_THREAD_NAME));
-        } else {
-            return false;
-        }
-    }
+				// Calculate CPU energy consumption of the process of the JVM all its apps
+				double processEnergy = calculateProcessCpuEnergy(cpuLoad, processCpuLoad, cpuEnergy);
+
+				// Adds current power to total energy
+				status.addConsumedEnergy(processEnergy);
+
+				// Now we have:
+				// CPU energy for JVM process
+				// CPU energy for all processes
+				// We need to calculate energy for each thread
+//                long totalThreadsCpuTime = updateThreadsCpuTime(methodsStats, threadsCpuTime);
+//                var threadCpuTimePercentages = getThreadsCpuTimePercentage(threadsCpuTime, totalThreadsCpuTime, processEnergy);
+
+				var threadCpuTimePercentages = getThreadsCpuTimePercentage(methodsStats, threadsCpuTime, processEnergy);
+
+				updateMethodsConsumedEnergy(methodsStats, threadCpuTimePercentages, status::addMethodConsumedEnergy,
+						Scope.ALL);
+				updateMethodsConsumedEnergy(methodsStatsFiltered, threadCpuTimePercentages,
+						status::addFilteredMethodConsumedEnergy, Scope.FILTERED);
+
+				// Updating call trees consumption if option is enabled
+				if (this.properties.callTreesConsumption()) {
+					updateCallTreesConsumedEnergy(callTreesStats, threadCpuTimePercentages,
+							status::addCallTreeConsumedEnergy);
+					updateCallTreesConsumedEnergy(filteredCallTreeStats, threadCpuTimePercentages,
+							status::addFilteredCallTreeConsumedEnergy);
+
+					// Writing runtime call trees power only if option is enabled
+					if (this.properties.saveCallTreesRuntimeData()) {
+						if (this.properties.overwriteCallTreesRuntimeData()) {
+							this.saveResults(callTreesStats, threadCpuTimePercentages,
+									this.resultTreeManager.getAllRuntimeCallTreePath()
+											+ String.format("/joularJX-%d-all-call-trees-power", appPid));
+							this.saveResults(filteredCallTreeStats, threadCpuTimePercentages,
+									this.resultTreeManager.getFilteredRuntimeCallTreePath()
+											+ String.format("/joularJX-%d-filtered-call-trees-power", appPid));
+						} else {
+							this.saveResults(callTreesStats, threadCpuTimePercentages,
+									this.resultTreeManager.getAllRuntimeCallTreePath()
+											+ String.format("/joularJX-%d-%d-all-call-trees-power", appPid,
+													System.currentTimeMillis()));
+							this.saveResults(filteredCallTreeStats, threadCpuTimePercentages,
+									this.resultTreeManager.getFilteredRuntimeCallTreePath()
+											+ String.format("/joularJX-%d-%d-filtered-call-trees-power", appPid,
+													System.currentTimeMillis()));
+						}
+					}
+				}
+
+				// Writing runtime method's power only if option is enabled
+				if (this.properties.savesRuntimeData()) {
+					if (this.properties.overwritesRuntimeData()) {
+						this.saveResults(methodsStats, threadCpuTimePercentages,
+								this.resultTreeManager.getAllRuntimeMethodsPath()
+										+ String.format("/joularJX-%d-all-methods-power", appPid));
+						this.saveResults(methodsStatsFiltered, threadCpuTimePercentages,
+								this.resultTreeManager.getFilteredRuntimeMethodsPath()
+										+ String.format("/joularJX-%d-filtered-methods-power", appPid));
+					} else {
+						this.saveResults(methodsStats, threadCpuTimePercentages,
+								this.resultTreeManager.getAllRuntimeMethodsPath() + String.format(
+										"/joularJX-%d-%d-all-methods-power", appPid, System.currentTimeMillis()));
+						this.saveResults(methodsStatsFiltered, threadCpuTimePercentages,
+								this.resultTreeManager.getFilteredRuntimeMethodsPath() + String.format(
+										"/joularJX-%d-%d-filtered-methods-power", appPid, System.currentTimeMillis()));
+					}
+				}
+
+				Thread.sleep(sampleRateMilliseconds);
+			} catch (InterruptedException exception) {
+				Thread.currentThread().interrupt();
+			} catch (IOException exception) {
+				logger.log(Level.SEVERE, "Cannot perform IO \"{0}\"", exception.getMessage());
+				logger.throwing(getClass().getName(), "run", exception);
+				System.exit(1);
+			}
+		}
+	}
+
+	/**
+	 * Performs the sampling step. Collects a set of stack traces for each thread.
+	 * The sampling step is performed multiple time at the frequecy of
+	 * SAMPLE_RATE_MILLSECONDS, for the duration of SAMPLE_TIME_MILLISECONDS
+	 *
+	 * @return for each Thread, a List of it's the stack traces
+	 */
+	private Map<Thread, List<StackTraceElement[]>> sample() {
+		Map<Thread, List<StackTraceElement[]>> result = new HashMap<>();
+		try {
+			for (int duration = 0; duration < sampleTimeMilliseconds; duration += sampleRateMilliseconds) {
+				for (var entry : Thread.getAllStackTraces().entrySet()) {
+					String threadName = entry.getKey().getName();
+					// Ignoring agent related threads, if option is enabled
+					if (this.properties.hideAgentConsumption() && (threadName.equals(Agent.COMPUTATION_THREAD_NAME))) {
+						continue; // Ignoring the thread
+					}
+
+					// Only check runnable threads (not waiting or blocked)
+					if (entry.getKey().getState() == Thread.State.RUNNABLE) {
+						var target = result.computeIfAbsent(entry.getKey(), t -> new ArrayList<>(sampleIterations));
+						target.add(entry.getValue());
+					}
+				}
+
+				Thread.sleep(sampleRateMilliseconds);
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+		}
+
+		return result;
+	}
+
+	/**
+	 * Writes the results in a file. The filename is partially defined by the given
+	 * parameters.
+	 *
+	 * @param <K>                      The type of key that will be written in the
+	 *                                 file. Must implement the toString() method.
+	 * @param stats                    the data to be written, given under the form
+	 *                                 of a Map<Thread, Map<K>, Double>> where the
+	 *                                 Double is the enrgy consumption.
+	 * @param threadCpuTimePercentages a map of CPU time usage per Thread (PID)
+	 * @param filePath                 the path of the file where the data will be
+	 *                                 written
+	 * @throws IOException if an I/O error occurs while writing the file
+	 */
+	public <K> void saveResults(Map<Thread, Map<K, Integer>> stats, Map<Long, Double> threadCpuTimePercentages,
+			String filePath) throws IOException {
+		for (final ResultWriter resultWriter : resultWriters) {
+			resultWriter.setTarget(filePath, true);
+		}
+
+		for (var statEntry : stats.entrySet()) {
+			for (var entry : statEntry.getValue().entrySet()) {
+				double power = threadCpuTimePercentages.get(statEntry.getKey().getId()) * (entry.getValue() / 100.0);
+				for (ResultWriter resultWriter : resultWriters) {
+					resultWriter.write(entry.getKey().toString(), power);
+				}
+			}
+		}
+
+		for (final ResultWriter resultWriter : resultWriters) {
+			resultWriter.closeTarget();
+		}
+	}
+
+	/**
+	 * Update call trees consumed energy.
+	 *
+	 * @param stats                    call trees encounters statistics per Thread
+	 * @param threadCpuTimePercentages map of CPU time usage per PID
+	 * @param callTreeConsumer         the method used to update the energy
+	 *                                 consumption
+	 */
+	private void updateCallTreesConsumedEnergy(Map<Thread, Map<CallTree, Integer>> stats,
+			Map<Long, Double> threadCpuTimePercentages, ObjDoubleConsumer<CallTree> callTreeConsumer) {
+		for (var entry : stats.entrySet()) {
+			double totalEncounters = entry.getValue().values().stream().mapToDouble(i -> i).sum();
+
+			for (var callTreeEntry : entry.getValue().entrySet()) {
+				double stackTracePower = 0.0;
+				if (totalEncounters >= Double.MIN_VALUE) {
+					stackTracePower = threadCpuTimePercentages.get(entry.getKey().getId())
+							* (callTreeEntry.getValue() / totalEncounters);
+				}
+
+				callTreeConsumer.accept(callTreeEntry.getKey(), stackTracePower);
+			}
+		}
+	}
+
+	/**
+	 * Update method's consumed energy.
+	 *
+	 * @param methodsStats               method's encounters statistics per Thread
+	 * @param threadCpuTimePercentages   a map of CPU time usage per PID
+	 * @param updateMethodConsumedEnergy an object consumer, used to update all or
+	 *                                   only filtered methods
+	 * @param scope                      the scope (all methods or only filterd
+	 *                                   methods). Used for energy consumption
+	 *                                   tracking
+	 */
+	private void updateMethodsConsumedEnergy(Map<Thread, Map<String, Integer>> methodsStats,
+			Map<Long, Double> threadCpuTimePercentages, ObjDoubleConsumer<String> updateMethodConsumedEnergy,
+			Scope scope) {
+		for (var threadEntry : methodsStats.entrySet()) {
+			double totalEncounters = threadEntry.getValue().values().stream().mapToDouble(i -> i).sum();
+			for (var methodEntry : threadEntry.getValue().entrySet()) {
+				double methodPower = 0.0;
+				if (totalEncounters >= Double.MIN_VALUE) {
+					methodPower = threadCpuTimePercentages.get(threadEntry.getKey().getId())
+							* (methodEntry.getValue() / totalEncounters);
+				}
+
+				// Only of consumption evolution tracking is enabled
+				if (this.properties.trackConsumptionEvolution()) {
+					// computing the UNIX EPOCH timestamp
+					long unixTimestamp = System.currentTimeMillis() / 1000L;
+
+					if (scope == Scope.ALL) {
+						this.status.trackMethodConsumption(methodEntry.getKey(), unixTimestamp, methodPower);
+					} else {
+						this.status.trackFilteredMethodConsumption(methodEntry.getKey(), unixTimestamp, methodPower);
+					}
+				}
+
+				updateMethodConsumedEnergy.accept(methodEntry.getKey(), methodPower);
+			}
+		}
+	}
 }

--- a/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
@@ -11,6 +11,7 @@
 package org.noureddine.joularjx.monitor;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -22,95 +23,122 @@ import org.noureddine.joularjx.utils.AgentProperties;
 import org.noureddine.joularjx.utils.JoularJXLogging;
 
 /**
- * The ShutdownHandler is meant to be called at the end of the agent and is responsible for displaying and writing all the consumption data in dedicated files.
- * It also performs resource closing operations.
+ * The ShutdownHandler is meant to be called at the end of the agent and is
+ * responsible for displaying and writing all the consumption data in dedicated
+ * files. It also performs resource closing operations.
  */
 public class ShutdownHandler implements Runnable {
 
-    private static final Logger logger = JoularJXLogging.getLogger();
+	private static final Logger logger = JoularJXLogging.getLogger();
 
-    private final long appPid;
-    private final ResultWriter resultWriter;
-    private final Cpu cpu;
-    private final MonitoringStatus status;
-    private final AgentProperties properties;
-    private final ResultTreeManager resultTreeManager;
+	private final long appPid;
+	private final List<ResultWriter> resultWriters;
+	private final Cpu cpu;
+	private final MonitoringStatus status;
+	private final AgentProperties properties;
+	private final ResultTreeManager resultTreeManager;
 
-    /**
-     * Creates a new ShutdownHandler.
-     * @param appPid the PID of the monitored application 
-     * @param resultWriter the writer that will be used to save data in files
-     * @param cpu an implementation of the CPU interface, depending on the OS and hardware
-     * @param status where all the runtime data will be saved
-     * @param properties the agent's configuration properties
-     * @param resultTreeManager the ResultTreeManager used to provide correct filepaths for the generated files
-     */
-    public ShutdownHandler(long appPid, ResultWriter resultWriter, Cpu cpu, MonitoringStatus status, AgentProperties properties, ResultTreeManager resultTreeManager) {
-        this.appPid = appPid;
-        this.resultWriter = resultWriter;
-        this.cpu = cpu;
-        this.status = status;
-        this.properties = properties;
-        this.resultTreeManager = resultTreeManager;
-    }
+	/**
+	 * Creates a new ShutdownHandler.
+	 *
+	 * @param appPid            the PID of the monitored application
+	 * @param resultWriters     the writer that will be used to save data in files
+	 * @param cpu               an implementation of the CPU interface, depending on
+	 *                          the OS and hardware
+	 * @param status            where all the runtime data will be saved
+	 * @param properties        the agent's configuration properties
+	 * @param resultTreeManager the ResultTreeManager used to provide correct
+	 *                          filepaths for the generated files
+	 */
+	public ShutdownHandler(long appPid, List<ResultWriter> resultWriters, Cpu cpu, MonitoringStatus status,
+			AgentProperties properties, ResultTreeManager resultTreeManager) {
+		this.appPid = appPid;
+		this.resultWriters = resultWriters;
+		this.cpu = cpu;
+		this.status = status;
+		this.properties = properties;
+		this.resultTreeManager = resultTreeManager;
+	}
 
-    @Override
-    public void run() {
-        // Close monitoring implementation to release all resources
-        try {
-            cpu.close();
-        } catch (Exception exception) {
-            // Continue shutting down
-        }
+	@Override
+	public void run() {
+		// Close monitoring implementation to release all resources
+		try {
+			cpu.close();
+		} catch (final Exception exception) {
+			// Continue shutting down
+		}
 
-        logger.log(Level.INFO, String.format("JoularJX finished monitoring application with ID %d", appPid));
-        logger.log(Level.INFO, "Program consumed {0,number,#.##} joules", status.getTotalConsumedEnergy());
+		logger.log(Level.INFO, String.format("JoularJX finished monitoring application with ID %d", appPid));
+		logger.log(Level.INFO, "Program consumed {0,number,#.##} joules", status.getTotalConsumedEnergy());
 
-        try {
-            //Writing methods and filtered methods energy consumption
-            this.saveResults(status.getMethodsConsumedEnergy(), this.resultTreeManager.getAllTotalMethodsPath()+String.format("/joularJX-%d-all-methods-energy", appPid));
-            this.saveResults(status.getFilteredMethodsConsumedEnergy(), this.resultTreeManager.getFilteredTotalMethodsPath()+String.format("/joularJX-%d-filtered-methods-energy", appPid));
-            
-            //Writing consumption evolution files only if the option is enabled
-            if (this.properties.trackConsumptionEvolution()) {
-                //All methods
-                for (var methodEntry : this.status.getMethodsConsumptionEvolution().entrySet()) {
-                    this.saveResults(methodEntry.getValue(), this.resultTreeManager.getAllEvolutionPath()+String.format("/joularJX-%d-%s-evolution", appPid, methodEntry.getKey().replace('<', '_').replace('>', '_')));
-                }
-                
-                //Filtered methods
-                for (var methodEntry : this.status.getFilteredMethodsConsumptionEvolution().entrySet()) {
-                    this.saveResults(methodEntry.getValue(), this.resultTreeManager.getFilteredEvolutionPath()+String.format("/joularJX-%d-%s-evolution", appPid, methodEntry.getKey().replace('<', '_').replace('>', '_')));
-                }
-            }
+		try {
+			// Writing methods and filtered methods energy consumption
+			this.saveResults(status.getMethodsConsumedEnergy(), this.resultTreeManager.getAllTotalMethodsPath()
+					+ String.format("/joularJX-%d-all-methods-energy", appPid));
+			this.saveResults(status.getFilteredMethodsConsumedEnergy(),
+					this.resultTreeManager.getFilteredTotalMethodsPath()
+							+ String.format("/joularJX-%d-filtered-methods-energy", appPid));
 
-            //Writing call trees consumption file only if the option is enabled
-            if (this.properties.callTreesConsumption()) {
-                this.saveResults(status.getCallTreesConsumedEnergy(), this.resultTreeManager.getAllTotalCallTreePath()+String.format("/joularJX-%d-all-call-trees-energy", appPid));
-                this.saveResults(status.getFilteredCallTreesConsumedEnergy(), this.resultTreeManager.getFilteredTotalCallTreePath()+String.format("/joularJX-%d-filtered-call-trees-energy", appPid));
-            }
-        } catch (IOException exception) {
-            // Continue shutting down
-        }
+			// Writing consumption evolution files only if the option is enabled
+			if (this.properties.trackConsumptionEvolution()) {
+				// All methods
+				for (final var methodEntry : this.status.getMethodsConsumptionEvolution().entrySet()) {
+					this.saveResults(methodEntry.getValue(),
+							this.resultTreeManager.getAllEvolutionPath() + String.format("/joularJX-%d-%s-evolution",
+									appPid, methodEntry.getKey().replace('<', '_').replace('>', '_')));
+				}
 
-        logger.log(Level.INFO, "Energy consumption of methods and filtered methods written to files");
-    }
+				// Filtered methods
+				for (final var methodEntry : this.status.getFilteredMethodsConsumptionEvolution().entrySet()) {
+					this.saveResults(methodEntry.getValue(),
+							this.resultTreeManager.getFilteredEvolutionPath()
+									+ String.format("/joularJX-%d-%s-evolution", appPid,
+											methodEntry.getKey().replace('<', '_').replace('>', '_')));
+				}
+			}
 
-    /**
-    * Writes the results in a file. The filename is partially defined by the given parameters.
-     * @param <K> The type of key that will be written in the file. Must implement the toString() method.*
-     * @param consumedEnergyMap the data to be written.
-     * @param filePath the path of the file where the data will be written.
-     * @throws IOException if an I/O error occurs while writing the data.
-     */
-    public <K> void saveResults(Map<K, Double> consumedEnergyMap, String filePath) throws IOException {
-        //String fileName = String.format("joularJX-%d-%s-%s", appPid, nodeType, dataType);
-        resultWriter.setTarget(filePath, true);
+			// Writing call trees consumption file only if the option is enabled
+			if (this.properties.callTreesConsumption()) {
+				this.saveResults(status.getCallTreesConsumedEnergy(), this.resultTreeManager.getAllTotalCallTreePath()
+						+ String.format("/joularJX-%d-all-call-trees-energy", appPid));
+				this.saveResults(status.getFilteredCallTreesConsumedEnergy(),
+						this.resultTreeManager.getFilteredTotalCallTreePath()
+								+ String.format("/joularJX-%d-filtered-call-trees-energy", appPid));
+			}
+		} catch (final IOException exception) {
+			// Continue shutting down
+		}
 
-        for (var entry : consumedEnergyMap.entrySet()) {
-            resultWriter.write(entry.getKey().toString(), entry.getValue());
-        }
+		logger.log(Level.INFO, "Energy consumption of methods and filtered methods written to files");
+	}
 
-        resultWriter.closeTarget();
-    }
+	/**
+	 * Writes the results in a file. The filename is partially defined by the given
+	 * parameters.
+	 *
+	 * @param <K>               The type of key that will be written in the file.
+	 *                          Must implement the toString() method.*
+	 * @param consumedEnergyMap the data to be written.
+	 * @param filePath          the path of the file where the data will be written.
+	 * @throws IOException if an I/O error occurs while writing the data.
+	 */
+	public <K> void saveResults(Map<K, Double> consumedEnergyMap, String filePath) throws IOException {
+		// String fileName = String.format("joularJX-%d-%s-%s", appPid, nodeType,
+		// dataType);
+		for (final ResultWriter resultWriter : resultWriters) {
+			resultWriter.setTarget(filePath, true);
+		}
+
+		for (final var entry : consumedEnergyMap.entrySet()) {
+			for (final ResultWriter resultWriter : resultWriters) {
+				resultWriter.write(entry.getKey().toString(), entry.getValue());
+			}
+		}
+
+		for (final ResultWriter resultWriter : resultWriters) {
+			resultWriter.closeTarget();
+		}
+
+	}
 }

--- a/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
+++ b/src/main/java/org/noureddine/joularjx/monitor/ShutdownHandler.java
@@ -17,8 +17,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.noureddine.joularjx.cpu.Cpu;
-import org.noureddine.joularjx.result.ResultTreeManager;
+import org.noureddine.joularjx.result.ResultScope;
 import org.noureddine.joularjx.result.ResultWriter;
+import org.noureddine.joularjx.result.ResultWriterConfiguration;
 import org.noureddine.joularjx.utils.AgentProperties;
 import org.noureddine.joularjx.utils.JoularJXLogging;
 
@@ -36,28 +37,24 @@ public class ShutdownHandler implements Runnable {
 	private final Cpu cpu;
 	private final MonitoringStatus status;
 	private final AgentProperties properties;
-	private final ResultTreeManager resultTreeManager;
 
 	/**
 	 * Creates a new ShutdownHandler.
 	 *
-	 * @param appPid            the PID of the monitored application
-	 * @param resultWriters     the writer that will be used to save data in files
-	 * @param cpu               an implementation of the CPU interface, depending on
-	 *                          the OS and hardware
-	 * @param status            where all the runtime data will be saved
-	 * @param properties        the agent's configuration properties
-	 * @param resultTreeManager the ResultTreeManager used to provide correct
-	 *                          filepaths for the generated files
+	 * @param appPid        the PID of the monitored application
+	 * @param resultWriters the writer that will be used to save data in files
+	 * @param cpu           an implementation of the CPU interface, depending on the
+	 *                      OS and hardware
+	 * @param status        where all the runtime data will be saved
+	 * @param properties    the agent's configuration properties
 	 */
 	public ShutdownHandler(long appPid, List<ResultWriter> resultWriters, Cpu cpu, MonitoringStatus status,
-			AgentProperties properties, ResultTreeManager resultTreeManager) {
+			AgentProperties properties) {
 		this.appPid = appPid;
 		this.resultWriters = resultWriters;
 		this.cpu = cpu;
 		this.status = status;
 		this.properties = properties;
-		this.resultTreeManager = resultTreeManager;
 	}
 
 	@Override
@@ -74,37 +71,32 @@ public class ShutdownHandler implements Runnable {
 
 		try {
 			// Writing methods and filtered methods energy consumption
-			this.saveResults(status.getMethodsConsumedEnergy(), this.resultTreeManager.getAllTotalMethodsPath()
-					+ String.format("/joularJX-%d-all-methods-energy", appPid));
+			this.saveResults(status.getMethodsConsumedEnergy(),
+					new ResultWriterConfiguration(ResultScope.ALL_TOTAL_METHODS));
 			this.saveResults(status.getFilteredMethodsConsumedEnergy(),
-					this.resultTreeManager.getFilteredTotalMethodsPath()
-							+ String.format("/joularJX-%d-filtered-methods-energy", appPid));
+					new ResultWriterConfiguration(ResultScope.FILTERED_TOTAL_METHODS));
 
 			// Writing consumption evolution files only if the option is enabled
 			if (this.properties.trackConsumptionEvolution()) {
 				// All methods
 				for (final var methodEntry : this.status.getMethodsConsumptionEvolution().entrySet()) {
-					this.saveResults(methodEntry.getValue(),
-							this.resultTreeManager.getAllEvolutionPath() + String.format("/joularJX-%d-%s-evolution",
-									appPid, methodEntry.getKey().replace('<', '_').replace('>', '_')));
+					this.saveResults(methodEntry.getValue(), new ResultWriterConfiguration(ResultScope.ALL_EVOLUTION,
+							sanitizeMethodName(methodEntry.getKey())));
 				}
 
 				// Filtered methods
 				for (final var methodEntry : this.status.getFilteredMethodsConsumptionEvolution().entrySet()) {
-					this.saveResults(methodEntry.getValue(),
-							this.resultTreeManager.getFilteredEvolutionPath()
-									+ String.format("/joularJX-%d-%s-evolution", appPid,
-											methodEntry.getKey().replace('<', '_').replace('>', '_')));
+					this.saveResults(methodEntry.getValue(), new ResultWriterConfiguration(
+							ResultScope.FILTERED_EVOLUTION, sanitizeMethodName(methodEntry.getKey())));
 				}
 			}
 
 			// Writing call trees consumption file only if the option is enabled
 			if (this.properties.callTreesConsumption()) {
-				this.saveResults(status.getCallTreesConsumedEnergy(), this.resultTreeManager.getAllTotalCallTreePath()
-						+ String.format("/joularJX-%d-all-call-trees-energy", appPid));
+				this.saveResults(status.getCallTreesConsumedEnergy(),
+						new ResultWriterConfiguration(ResultScope.ALL_TOTAL_CALL_TREE));
 				this.saveResults(status.getFilteredCallTreesConsumedEnergy(),
-						this.resultTreeManager.getFilteredTotalCallTreePath()
-								+ String.format("/joularJX-%d-filtered-call-trees-energy", appPid));
+						new ResultWriterConfiguration(ResultScope.FILTERED_TOTAL_CALL_TREE));
 			}
 		} catch (final IOException exception) {
 			// Continue shutting down
@@ -114,20 +106,30 @@ public class ShutdownHandler implements Runnable {
 	}
 
 	/**
-	 * Writes the results in a file. The filename is partially defined by the given
+	 * Cleans a method name to make it suitable for inclusion in a filename
+	 *
+	 * @param methodName the method name
+	 * @return the sanitized version
+	 */
+	private String sanitizeMethodName(String methodName) {
+		return methodName.replaceAll("[<>]", "_");
+	}
+
+	/**
+	 * Writes the results. The filename is partially defined by the given
 	 * parameters.
 	 *
 	 * @param <K>               The type of key that will be written in the file.
-	 *                          Must implement the toString() method.*
+	 *                          Must implement the {@code toString()} method.
 	 * @param consumedEnergyMap the data to be written.
-	 * @param filePath          the path of the file where the data will be written.
+	 * @param config            configuration for the writers
 	 * @throws IOException if an I/O error occurs while writing the data.
 	 */
-	public <K> void saveResults(Map<K, Double> consumedEnergyMap, String filePath) throws IOException {
+	public <K> void saveResults(Map<K, Double> consumedEnergyMap, ResultWriterConfiguration config) throws IOException {
 		// String fileName = String.format("joularJX-%d-%s-%s", appPid, nodeType,
 		// dataType);
 		for (final ResultWriter resultWriter : resultWriters) {
-			resultWriter.setTarget(filePath, true);
+			resultWriter.setConfiguration(config);
 		}
 
 		for (final var entry : consumedEnergyMap.entrySet()) {

--- a/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
@@ -17,6 +17,8 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Properties;
 
 import com.google.auto.service.AutoService;
 
@@ -47,9 +49,23 @@ public class CsvResultWriter implements ResultWriter {
 
 	/** {@inheritDoc} */
 	@Override
+	public void setProperties(Properties props) {
+		// TODO Auto-generated method stub
+
+	}
+
+	/** {@inheritDoc} */
+	@Override
+	public void setTarget(ResultScope scope, boolean overwrite) throws IOException {
+		// TODO Auto-generated method stub
+
+	}
+
+	/** {@inheritDoc} */
+	@Override
 	public void setTarget(String name, boolean overwrite) throws IOException {
 		final BufferedWriter previousWriter = writer.get();
-		if (previousWriter != null) {
+		if (Objects.nonNull(previousWriter)) {
 			previousWriter.close();
 		}
 

--- a/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
@@ -18,7 +18,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Properties;
+
+import org.noureddine.joularjx.utils.AgentProperties;
 
 import com.google.auto.service.AutoService;
 
@@ -31,6 +32,8 @@ public class CsvResultWriter implements ResultWriter {
 			StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING };
 
 	private final ThreadLocal<BufferedWriter> writer;
+
+	private AgentProperties props;
 
 	public CsvResultWriter() {
 		this.writer = new ThreadLocal<>();
@@ -49,8 +52,8 @@ public class CsvResultWriter implements ResultWriter {
 
 	/** {@inheritDoc} */
 	@Override
-	public void setProperties(Properties props) {
-		// TODO Auto-generated method stub
+	public void setProperties(AgentProperties props, long pid, long timestamp) {
+		this.props = props;
 
 	}
 

--- a/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
@@ -18,46 +18,52 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Locale;
 
+import com.google.auto.service.AutoService;
+
+@AutoService(ResultWriter.class)
 public class CsvResultWriter implements ResultWriter {
 
-    private static final OpenOption[] APPEND_OPEN_OPTIONS =
-            new OpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.APPEND};
-    private static final OpenOption[] OVERWRITE_OPEN_OPTIONS
-            = new OpenOption[] {StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING};
+	private static final OpenOption[] APPEND_OPEN_OPTIONS = new OpenOption[] { StandardOpenOption.CREATE,
+			StandardOpenOption.WRITE, StandardOpenOption.APPEND };
+	private static final OpenOption[] OVERWRITE_OPEN_OPTIONS = new OpenOption[] { StandardOpenOption.CREATE,
+			StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING };
 
-    private final ThreadLocal<BufferedWriter> writer;
+	private final ThreadLocal<BufferedWriter> writer;
 
-    public CsvResultWriter() {
-        this.writer = new ThreadLocal<>();
-    }
+	public CsvResultWriter() {
+		this.writer = new ThreadLocal<>();
+	}
 
-    @Override
-    public void setTarget(String name, boolean overwrite) throws IOException {
-        BufferedWriter previousWriter = writer.get();
-        if (previousWriter != null) {
-            previousWriter.close();
-        }
+	/** {@inheritDoc} */
+	@Override
+	public void closeTarget() throws IOException {
+		writer.get().close();
+		writer.remove();
+	}
 
-        writer.set(Files.newBufferedWriter(getPath(name), overwrite ? OVERWRITE_OPEN_OPTIONS : APPEND_OPEN_OPTIONS));
-    }
+	private Path getPath(String name) {
+		return Path.of(name + ".csv");
+	}
 
-    @Override
-    public void write(String methodName, double methodPower) throws IOException {
-        BufferedWriter writer = this.writer.get();
-        if (writer == null) {
-            throw new IllegalStateException("Please call ResultWriter#setTarget(String) first");
-        }
+	/** {@inheritDoc} */
+	@Override
+	public void setTarget(String name, boolean overwrite) throws IOException {
+		final BufferedWriter previousWriter = writer.get();
+		if (previousWriter != null) {
+			previousWriter.close();
+		}
 
-        writer.write(String.format(Locale.US, "%s,%.4f%n", methodName, methodPower));
-    }
+		writer.set(Files.newBufferedWriter(getPath(name), overwrite ? OVERWRITE_OPEN_OPTIONS : APPEND_OPEN_OPTIONS));
+	}
 
-    @Override
-    public void closeTarget() throws IOException {
-        writer.get().close();
-        writer.remove();
-    }
+	/** {@inheritDoc} */
+	@Override
+	public void write(String methodName, double methodPower) throws IOException {
+		final BufferedWriter writer = this.writer.get();
+		if (writer == null) {
+			throw new IllegalStateException("Please call ResultWriter#setTarget(String) first");
+		}
 
-    private Path getPath(String name) {
-        return Path.of(name + ".csv");
-    }
+		writer.write(String.format(Locale.US, "%s,%.4f%n", methodName, methodPower));
+	}
 }

--- a/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
@@ -33,8 +33,11 @@ public class CsvResultWriter implements ResultWriter {
 
 	private final ThreadLocal<BufferedWriter> writer;
 
-	private AgentProperties props;
+	private ResultTreeManager rtManager;
 
+	/**
+	 * Constructor
+	 */
 	public CsvResultWriter() {
 		this.writer = new ThreadLocal<>();
 	}
@@ -46,40 +49,39 @@ public class CsvResultWriter implements ResultWriter {
 		writer.remove();
 	}
 
-	private Path getPath(String name) {
-		return Path.of(name + ".csv");
+	private Path getCsvPath(Path path) {
+		return path.resolveSibling(path.getFileName() + ".csv");
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public void setProperties(AgentProperties props, long pid, long timestamp) {
-		this.props = props;
-
+	public void initialize(AgentProperties props, long pid, long timestamp) {
+		rtManager = new ResultTreeManager(props, pid, timestamp);
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public void setTarget(ResultScope scope, boolean overwrite) throws IOException {
-		// TODO Auto-generated method stub
-
+	public void setConfiguration(ResultWriterConfiguration configuration) throws IOException {
+		final ResultTreeManager.PathBuilder builder = rtManager.new PathBuilder(configuration.getScope());
+		final Path target = builder.withMethodName(configuration.getMethodName())
+				.withTimestamp(configuration.isTimestamped()).build();
+		setTarget(target, configuration.isOverwrite());
 	}
 
-	/** {@inheritDoc} */
-	@Override
-	public void setTarget(String name, boolean overwrite) throws IOException {
+	private void setTarget(Path name, boolean overwrite) throws IOException {
 		final BufferedWriter previousWriter = writer.get();
 		if (Objects.nonNull(previousWriter)) {
 			previousWriter.close();
 		}
 
-		writer.set(Files.newBufferedWriter(getPath(name), overwrite ? OVERWRITE_OPEN_OPTIONS : APPEND_OPEN_OPTIONS));
+		writer.set(Files.newBufferedWriter(getCsvPath(name), overwrite ? OVERWRITE_OPEN_OPTIONS : APPEND_OPEN_OPTIONS));
 	}
 
 	/** {@inheritDoc} */
 	@Override
 	public void write(String methodName, double methodPower) throws IOException {
 		final BufferedWriter writer = this.writer.get();
-		if (writer == null) {
+		if (Objects.isNull(writer)) {
 			throw new IllegalStateException("Please call ResultWriter#setTarget(String) first");
 		}
 

--- a/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/CsvResultWriter.java
@@ -62,7 +62,7 @@ public class CsvResultWriter implements ResultWriter {
 	/** {@inheritDoc} */
 	@Override
 	public void setConfiguration(ResultWriterConfiguration configuration) throws IOException {
-		final ResultTreeManager.PathBuilder builder = rtManager.new PathBuilder(configuration.getScope());
+		final ResultTreeManager.PathBuilder builder = rtManager.getBuilder(configuration.getScope());
 		final Path target = builder.withMethodName(configuration.getMethodName())
 				.withTimestamp(configuration.isTimestamped()).build();
 		setTarget(target, configuration.isOverwrite());

--- a/src/main/java/org/noureddine/joularjx/result/ResultScope.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultScope.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021-2024, Adel Noureddine, Université de Pau et des Pays de l'Adour.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the
+ * GNU General Public License v3.0 only (GPL-3.0-only)
+ * which accompanies this distribution, and is available at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+
+package org.noureddine.joularjx.result;
+
+public enum ResultScope {
+	ALL_EVOLUTION,
+	FILTERED_EVOLUTION,
+	ALL_RUNTIME_CALL_TREE,
+	FILTERED_RUNTIME_CALL_TREE,
+	ALL_RUNTIME_METHODS,
+	FILTERED_RUNTIME_METHODS,
+	ALL_TOTAL_CALL_TREE,
+	FILTERED_TOTAL_CALL_TREE,
+	ALL_TOTAL_METHODS,
+	FILTERED_TOTAL_METHODS
+}

--- a/src/main/java/org/noureddine/joularjx/result/ResultScope.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultScope.java
@@ -11,8 +11,8 @@
 package org.noureddine.joularjx.result;
 
 public enum ResultScope {
-	ALL_EVOLUTION("all", "evolution"),
-	FILTERED_EVOLUTION("filtered", "evolution"),
+	ALL_EVOLUTION("", "evolution"),
+	FILTERED_EVOLUTION("", "evolution"),
 	ALL_RUNTIME_CALL_TREE("all", "call-trees-power"),
 	FILTERED_RUNTIME_CALL_TREE("filtered", "call-trees-power"),
 	ALL_RUNTIME_METHODS("all", "methods-power"),

--- a/src/main/java/org/noureddine/joularjx/result/ResultScope.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultScope.java
@@ -11,14 +11,42 @@
 package org.noureddine.joularjx.result;
 
 public enum ResultScope {
-	ALL_EVOLUTION,
-	FILTERED_EVOLUTION,
-	ALL_RUNTIME_CALL_TREE,
-	FILTERED_RUNTIME_CALL_TREE,
-	ALL_RUNTIME_METHODS,
-	FILTERED_RUNTIME_METHODS,
-	ALL_TOTAL_CALL_TREE,
-	FILTERED_TOTAL_CALL_TREE,
-	ALL_TOTAL_METHODS,
-	FILTERED_TOTAL_METHODS
+	ALL_EVOLUTION("all", "evolution"),
+	FILTERED_EVOLUTION("filtered", "evolution"),
+	ALL_RUNTIME_CALL_TREE("all", "call-trees-power"),
+	FILTERED_RUNTIME_CALL_TREE("filtered", "call-trees-power"),
+	ALL_RUNTIME_METHODS("all", "methods-power"),
+	FILTERED_RUNTIME_METHODS("filtered", "methods-power"),
+	ALL_TOTAL_CALL_TREE("all", "call-trees-energy"),
+	FILTERED_TOTAL_CALL_TREE("filtered", "call-trees-energy"),
+	ALL_TOTAL_METHODS("all", "methods-energy"),
+	FILTERED_TOTAL_METHODS("filtered", "methods-energy");
+	
+	String scope;
+	String suffix;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param string  scope (all or filtered)
+	 * @param string2 suffix for the file names
+	 */
+	ResultScope(String string, String string2) {
+		scope = string;
+		suffix = string2;
+	}
+
+	/**
+	 * @return the scope
+	 */
+	public String getScope() {
+		return scope;
+	}
+
+	/**
+	 * @return the suffix
+	 */
+	public String getSuffix() {
+		return suffix;
+	}
 }

--- a/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
@@ -11,6 +11,8 @@
 package org.noureddine.joularjx.result;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
@@ -20,211 +22,236 @@ import org.noureddine.joularjx.utils.AgentProperties;
 import org.noureddine.joularjx.utils.JoularJXLogging;
 
 /**
- * The ResultTreeManager provides a method to create the required folder hierarchy, enabling the agent to write data in files later on.
- * This class also provides methods that return the proper filepath depending on the type (method, call-tree, ...) and granularity (all, filtered) of the data.
+ * The ResultTreeManager provides a method to create the required folder
+ * hierarchy, enabling the agent to write data in files later on. This class
+ * also provides methods that return the proper filepath depending on the type
+ * (method, call-tree, ...) and granularity (all, filtered) of the data.
  */
 public class ResultTreeManager {
 
-    private static final Logger logger = JoularJXLogging.getLogger();
+	private static final Logger logger = JoularJXLogging.getLogger();
 
-    // Folders names
-    public final static String GLOBAL_RESULT_DIRECTORY_NAME = "joularjx-result";
+	// Folders names
+	public final static String GLOBAL_RESULT_DIRECTORY_NAME = "joularjx-result";
 
-    public final static String ALL_DIRECTORY_NAME = "all";
-    public final static String FILTERED_DIRECTORY_NAME = "app";
+	public final static String ALL_DIRECTORY_NAME = "all";
+	public final static String FILTERED_DIRECTORY_NAME = "app";
 
-    public final static String RUNTIME_DIRECTORY_NAME = "runtime";
-    public final static String TOTAL_DIRECTORY_NAME = "total";
-    public final static String EVOLUTION_DIRECTORY_NAME = "evolution";
+	public final static String RUNTIME_DIRECTORY_NAME = "runtime";
+	public final static String TOTAL_DIRECTORY_NAME = "total";
+	public final static String EVOLUTION_DIRECTORY_NAME = "evolution";
 
-    public final static String CALLTREE_DIRECTORY_NAME = "calltrees";
-    public final static String METHOD_DIRECTORY_NAME = "methods";
+	public final static String CALLTREE_DIRECTORY_NAME = "calltrees";
+	public final static String METHOD_DIRECTORY_NAME = "methods";
 
-    private AgentProperties properties;
+	private final AgentProperties properties;
 
-    // The directory where the result of the current execution will be written
-    private String runDirectoryPath;
+	// The directory where the result of the current execution will be written
+	private final Path runDirectoryPath;
 
-    // All leaf directory paths
-    private String allTotalMethodsPath;
-    private String filteredTotalMethodsPath;
-    private String allRuntimeMethodsPath;
-    private String filteredRuntimeMethodsPath;
+	// All leaf directory paths
+	private final Path allTotalMethodsPath;
+	private final Path filteredTotalMethodsPath;
+	private final Path allRuntimeMethodsPath;
+	private final Path filteredRuntimeMethodsPath;
 
-    private String allRuntimeCallTreePath;
-    private String filteredRuntimeCallTreePath;
-    private String allTotalCallTreePath;
-    private String filteredTotalCallTreePath;
+	private final Path allRuntimeCallTreePath;
+	private final Path filteredRuntimeCallTreePath;
+	private final Path allTotalCallTreePath;
+	private final Path filteredTotalCallTreePath;
 
-    private String allEvolutionPath;
-    private String filteredEvolutionPath;
+	private final Path allEvolutionPath;
+	private final Path filteredEvolutionPath;
 
-    /**
-     * Creates a new ResultTreeManager. All the filepaths will be initialized (but not created yet!) with the informations provided by the given configuration properties.
-     * @param properties the agent's configuration properties
-     * @param pid the application PID
-     * @param startTimestamp the timestamp at which the creation has been initialized
-     */
-    public ResultTreeManager(AgentProperties properties, long pid, long startTimestamp) {
-        this.properties = properties;
-        
-        // Building the path of all the directories
-        this.runDirectoryPath =  GLOBAL_RESULT_DIRECTORY_NAME + "/" + String.format("%d-%d", pid, startTimestamp);
+	/**
+	 * Creates a new ResultTreeManager. All the filepaths will be initialized (but
+	 * not created yet!) with the informations provided by the given configuration
+	 * properties.
+	 *
+	 * @param properties     the agent's configuration properties
+	 * @param pid            the application PID
+	 * @param startTimestamp the timestamp at which the creation has been
+	 *                       initialized
+	 */
+	public ResultTreeManager(AgentProperties properties, long pid, long startTimestamp) {
+		this.properties = properties;
 
-        String allDirectoryPath      = runDirectoryPath + "/" + ALL_DIRECTORY_NAME;
-        String filteredDirectoryPath = runDirectoryPath + "/" + FILTERED_DIRECTORY_NAME;
+		// Building the path of all the directories
+		this.runDirectoryPath = Paths.get(GLOBAL_RESULT_DIRECTORY_NAME, String.format("%d-%d", pid, startTimestamp));
 
-        
-        this.allTotalMethodsPath        = allDirectoryPath + "/" + TOTAL_DIRECTORY_NAME + "/" + METHOD_DIRECTORY_NAME;
-        this.filteredTotalMethodsPath   = filteredDirectoryPath + "/" + TOTAL_DIRECTORY_NAME + "/" + METHOD_DIRECTORY_NAME;
-        this.allRuntimeMethodsPath      = allDirectoryPath + "/" + RUNTIME_DIRECTORY_NAME + "/" + METHOD_DIRECTORY_NAME;
-        this.filteredRuntimeMethodsPath = filteredDirectoryPath + "/" + RUNTIME_DIRECTORY_NAME + "/" + METHOD_DIRECTORY_NAME;
+		final Path allDirectoryPath = runDirectoryPath.resolve(ALL_DIRECTORY_NAME);
+		final Path filteredDirectoryPath = runDirectoryPath.resolve(FILTERED_DIRECTORY_NAME);
 
-        this.allRuntimeCallTreePath      = allDirectoryPath + "/" + RUNTIME_DIRECTORY_NAME + "/" + CALLTREE_DIRECTORY_NAME;
-        this.filteredRuntimeCallTreePath = filteredDirectoryPath + "/" + RUNTIME_DIRECTORY_NAME + "/" + CALLTREE_DIRECTORY_NAME;
-        this.allTotalCallTreePath        = allDirectoryPath + "/" + TOTAL_DIRECTORY_NAME + "/" + CALLTREE_DIRECTORY_NAME;
-        this.filteredTotalCallTreePath   = filteredDirectoryPath + "/" + TOTAL_DIRECTORY_NAME + "/" + CALLTREE_DIRECTORY_NAME;
+		this.allTotalMethodsPath = allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME);
+		this.filteredTotalMethodsPath = filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME)
+				.resolve(METHOD_DIRECTORY_NAME);
+		this.allRuntimeMethodsPath = allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME);
+		this.filteredRuntimeMethodsPath = filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME)
+				.resolve(METHOD_DIRECTORY_NAME);
 
-        this.allEvolutionPath      = allDirectoryPath + "/" + EVOLUTION_DIRECTORY_NAME;
-        this.filteredEvolutionPath = filteredDirectoryPath + "/" + EVOLUTION_DIRECTORY_NAME;
+		this.allRuntimeCallTreePath = allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME);
+		this.filteredRuntimeCallTreePath = filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME)
+				.resolve(CALLTREE_DIRECTORY_NAME);
+		this.allTotalCallTreePath = allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME);
+		this.filteredTotalCallTreePath = filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME)
+				.resolve(CALLTREE_DIRECTORY_NAME);
 
-    }
+		this.allEvolutionPath = allDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME);
+		this.filteredEvolutionPath = filteredDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME);
 
-    /**
-     * Creates the tree hierarchy. Creates the required folder, if they do not exist yet.
-     * Only the necessary folders are created, depending on the provided configuration properties.
-     * @return a boolean indicating whether an error occurs while creating the folder hierarchy (false), or no (true).
-     */
-    public boolean create() {
-        // This boolean acts as a check. If an error occurs during the initialization of the file hierarchy, the method will 
-        // continue its execution, as other directories may be created successfully, but this boolean will be set to false,
-        // to indicate that an error occurred.
-        boolean verif = true; 
+	}
 
-        logger.log(Level.INFO, String.format("Results will be stored in %s%s", this.runDirectoryPath, File.separator));
+	/**
+	 * Creates the tree hierarchy. Creates the required folder, if they do not exist
+	 * yet. Only the necessary folders are created, depending on the provided
+	 * configuration properties.
+	 *
+	 * @return a boolean indicating whether an error occurs while creating the
+	 *         folder hierarchy (false), or no (true).
+	 */
+	public boolean create() {
+		// This boolean acts as a check. If an error occurs during the initialization of
+		// the file hierarchy, the method will
+		// continue its execution, as other directories may be created successfully, but
+		// this boolean will be set to false,
+		// to indicate that an error occurred.
+		boolean verif = true;
 
-        // List of all the directories that will be created
-        List<String> directoriesToCreate = new ArrayList<>();
+		logger.log(Level.INFO, String.format("Results will be stored in %s%s", this.runDirectoryPath, File.separator));
 
-        // Mandatory directories (directories that do not depend of configuration properties)
-        directoriesToCreate.add(this.allTotalMethodsPath);
-        directoriesToCreate.add(this.filteredTotalMethodsPath);
+		// List of all the directories that will be created
+		final List<Path> directoriesToCreate = new ArrayList<>();
 
-        // Optional directories (directories that depends of configuration properties)
-        // Runtime
-        if (properties.savesRuntimeData()) {
-            directoriesToCreate.add(this.allRuntimeMethodsPath);
-            directoriesToCreate.add(this.filteredRuntimeMethodsPath);
-        }
+		// Mandatory directories (directories that do not depend of configuration
+		// properties)
+		directoriesToCreate.add(this.allTotalMethodsPath);
+		directoriesToCreate.add(this.filteredTotalMethodsPath);
 
-        // Call trees
-        if (properties.callTreesConsumption()) {
-            // Runtime
-            if (properties.saveCallTreesRuntimeData()) {
-                directoriesToCreate.add(this.allRuntimeCallTreePath);
-                directoriesToCreate.add(this.filteredRuntimeCallTreePath);
-            }
-            // Total
-            directoriesToCreate.add(this.allTotalCallTreePath);
-            directoriesToCreate.add(this.filteredTotalCallTreePath);
-        }
+		// Optional directories (directories that depends of configuration properties)
+		// Runtime
+		if (properties.savesRuntimeData()) {
+			directoriesToCreate.add(this.allRuntimeMethodsPath);
+			directoriesToCreate.add(this.filteredRuntimeMethodsPath);
+		}
 
-        // Methods consumption evolution
-        if (properties.trackConsumptionEvolution()) {
-            directoriesToCreate.add(this.allEvolutionPath);
-            directoriesToCreate.add(this.filteredEvolutionPath);
-        }
+		// Call trees
+		if (properties.callTreesConsumption()) {
+			// Runtime
+			if (properties.saveCallTreesRuntimeData()) {
+				directoriesToCreate.add(this.allRuntimeCallTreePath);
+				directoriesToCreate.add(this.filteredRuntimeCallTreePath);
+			}
+			// Total
+			directoriesToCreate.add(this.allTotalCallTreePath);
+			directoriesToCreate.add(this.filteredTotalCallTreePath);
+		}
 
-        // Creating all the directories
-        for (String dirPath : directoriesToCreate) {
-            File dir = new File(dirPath);
-            if (!dir.exists() && !dir.mkdirs()) {
-                logger.log(Level.WARNING, String.format("Failed to create directory %s", dirPath));
-                verif = false;
-            }
-        }
+		// Methods consumption evolution
+		if (properties.trackConsumptionEvolution()) {
+			directoriesToCreate.add(this.allEvolutionPath);
+			directoriesToCreate.add(this.filteredEvolutionPath);
+		}
 
-        return verif;
-    }
+		// Creating all the directories
+		for (final Path dirPath : directoriesToCreate) {
+			final File dir = dirPath.toFile();
+			if (!dir.exists() && !dir.mkdirs()) {
+				logger.log(Level.WARNING, String.format("Failed to create directory %s", dirPath));
+				verif = false;
+			}
+		}
 
-    /**
-     * Returns the path to the methods runtime consumption folder
-     * @return the path to the methods runtime consumption folder
-     */
-    public String getAllRuntimeMethodsPath() {
-        return this.allRuntimeMethodsPath;
-    }
+		return verif;
+	}
 
-    /**
-     * Returns the path to the methods total consumption folder
-     * @return the path to the methods total consumption folder
-     */
-    public String getAllTotalMethodsPath() {
-        return this.allTotalMethodsPath;
-    }
+	/**
+	 * Returns the path to the methods consumption evolution folder
+	 *
+	 * @return the path to the methods consumption evolution folder
+	 */
+	public Path getAllEvolutionPath() {
+		return this.allEvolutionPath;
+	}
 
-    /**
-     * Returns the path to the filtered methods runtime consumption folder
-     * @return the path to the filtered methods runtime consumption folder
-     */
-    public String getFilteredRuntimeMethodsPath() {
-        return this.filteredRuntimeMethodsPath;
-    }
+	/**
+	 * Returns the path to the call trees runtime consumption folder
+	 *
+	 * @return the path to the call trees runtime consumption folder
+	 */
+	public Path getAllRuntimeCallTreePath() {
+		return this.allRuntimeCallTreePath;
+	}
 
-    /**
-     * Returns the path to the filtered methods total consumption folder
-     * @return the path to the filtered methods total consumption folder
-     */
-    public String getFilteredTotalMethodsPath() {
-        return this.filteredTotalMethodsPath;
-    }
+	/**
+	 * Returns the path to the methods runtime consumption folder
+	 *
+	 * @return the path to the methods runtime consumption folder
+	 */
+	public Path getAllRuntimeMethodsPath() {
+		return this.allRuntimeMethodsPath;
+	}
 
-    /**
-     * Returns the path to the call trees runtime consumption folder
-     * @return the path to the call trees runtime consumption folder
-     */
-    public String getAllRuntimeCallTreePath() {
-        return this.allRuntimeCallTreePath;
-    }
+	/**
+	 * Returns the path to the call trees total consumption folder
+	 *
+	 * @return the path to the call trees total consumption folder
+	 */
+	public Path getAllTotalCallTreePath() {
+		return this.allTotalCallTreePath;
+	}
 
-    /**
-     * Returns the path to the call trees total consumption folder
-     * @return the path to the call trees total consumption folder
-     */
-    public String getAllTotalCallTreePath() {
-        return this.allTotalCallTreePath;
-    }
+	/**
+	 * Returns the path to the methods total consumption folder
+	 *
+	 * @return the path to the methods total consumption folder
+	 */
+	public Path getAllTotalMethodsPath() {
+		return this.allTotalMethodsPath;
+	}
 
-    /**
-     * Returns the path to the filtered call trees runtime consumption folder
-     * @return the path to the filtered call trees runtime consumption folder
-     */
-    public String getFilteredRuntimeCallTreePath() {
-        return this.filteredRuntimeCallTreePath;
-    }
+	/**
+	 * Returns the path to the filtered methods consumption evolution folder
+	 *
+	 * @return the path to the filtered methods consumption evolution folder
+	 */
+	public Path getFilteredEvolutionPath() {
+		return this.filteredEvolutionPath;
+	}
 
-    /**
-     * Returns the path to the filtered call trees total consumption folder
-     * @return the path to the filtered call trees total consumption folder
-     */
-    public String getFilteredTotalCallTreePath() {
-        return this.filteredTotalCallTreePath;
-    }
+	/**
+	 * Returns the path to the filtered call trees runtime consumption folder
+	 *
+	 * @return the path to the filtered call trees runtime consumption folder
+	 */
+	public Path getFilteredRuntimeCallTreePath() {
+		return this.filteredRuntimeCallTreePath;
+	}
 
-    /**
-     * Returns the path to the methods consumption evolution folder
-     * @return the path to the methods consumption evolution folder
-     */
-    public String getAllEvolutionPath() {
-        return this.allEvolutionPath;
-    }
+	/**
+	 * Returns the path to the filtered methods runtime consumption folder
+	 *
+	 * @return the path to the filtered methods runtime consumption folder
+	 */
+	public Path getFilteredRuntimeMethodsPath() {
+		return this.filteredRuntimeMethodsPath;
+	}
 
-    /**
-     * Returns the path to the filtered methods consumption evolution folder
-     * @return the path to the filtered methods consumption evolution folder
-     */
-    public String getFilteredEvolutionPath() {
-        return this.filteredEvolutionPath;
-    }
-    
+	/**
+	 * Returns the path to the filtered call trees total consumption folder
+	 *
+	 * @return the path to the filtered call trees total consumption folder
+	 */
+	public Path getFilteredTotalCallTreePath() {
+		return this.filteredTotalCallTreePath;
+	}
+
+	/**
+	 * Returns the path to the filtered methods total consumption folder
+	 *
+	 * @return the path to the filtered methods total consumption folder
+	 */
+	public Path getFilteredTotalMethodsPath() {
+		return this.filteredTotalMethodsPath;
+	}
+
 }

--- a/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
@@ -39,10 +39,13 @@ public class ResultTreeManager {
 	public class PathBuilder {
 
 		private boolean timestamp;
-		private ResultScope scope;
+		private final ResultScope scope;
 		private String methodName;
 
 		/**
+		 * Constructor with argument. Since scope is mandatory, it makes sense to impose
+		 * it as a constructor argument.
+		 *
 		 * @param scope the scope
 		 */
 		public PathBuilder(ResultScope scope) {
@@ -63,7 +66,11 @@ public class ResultTreeManager {
 			if (Objects.nonNull(methodName)) {
 				joiner.add(methodName);
 			}
-			joiner.add(scope.getScope()).add(scope.getSuffix());
+			if (!scope.getScope().isBlank()) {
+				// Handle edge case for evolution scopes
+				joiner.add(scope.getScope());
+			}
+			joiner.add(scope.getSuffix());
 
 			final String fileName = joiner.toString();
 			return leafPaths.get(scope).resolve(fileName);
@@ -77,17 +84,6 @@ public class ResultTreeManager {
 		 */
 		public PathBuilder withMethodName(String methodName) {
 			this.methodName = methodName;
-			return this;
-		}
-
-		/**
-		 * Sets the result scope.
-		 *
-		 * @param scope the {@link ResultScope} to set
-		 * @return this builder instance
-		 */
-		public PathBuilder withScope(ResultScope scope) {
-			this.scope = scope;
 			return this;
 		}
 
@@ -171,8 +167,8 @@ public class ResultTreeManager {
 	}
 
 	/**
-	 * Creates the tree hierarchy. Creates the required folders, if they do not exist
-	 * yet. Only the necessary folders are created, depending on the provided
+	 * Creates the tree hierarchy. Creates the required folders, if they do not
+	 * exist yet. Only the necessary folders are created, depending on the provided
 	 * configuration properties.
 	 *
 	 * @return a boolean indicating whether an error occurs while creating the
@@ -240,98 +236,39 @@ public class ResultTreeManager {
 	 *
 	 * @return the path to the methods consumption evolution folder
 	 */
-	public Path getAllEvolutionPath(String methodName) {
+	Path getAllEvolutionPath(String methodName) {
 		return new PathBuilder(ResultScope.ALL_EVOLUTION).withMethodName(methodName).build();
 	}
 
 	/**
-	 * Returns the path to the call trees runtime consumption file
+	 * Get a {@link PathBuilder} ready to use
 	 *
-	 * @param timestamped if the file must have the current timestamp in its name
-	 * @return the path to the call trees runtime consumption file
+	 * @param scope scope to use
+	 * @return the initialized builder
 	 */
-	public Path getAllRuntimeCallTreePath(boolean timestamped) {
-		return new PathBuilder(ResultScope.ALL_RUNTIME_CALL_TREE).withTimestamp(timestamped).build();
-	}
-
-	/**
-	 * Returns the path to the methods runtime consumption file
-	 *
-	 * @param timestamped if the file must have the current timestamp in its name
-	 * @return the path to the methods runtime consumption file
-	 */
-	public Path getAllRuntimeMethodsPath(boolean timestamped) {
-		return new PathBuilder(ResultScope.ALL_RUNTIME_METHODS).withTimestamp(timestamped).build();
-	}
-
-	/**
-	 * Returns the path to the call trees total consumption file
-	 *
-	 * @return the path to the call trees total consumption file
-	 */
-	public Path getAllTotalCallTreePath() {
-		return getPath(ResultScope.ALL_TOTAL_CALL_TREE);
-	}
-
-	/**
-	 * Returns the path to the methods total consumption file
-	 *
-	 * @return the path to the methods total consumption file
-	 */
-	public Path getAllTotalMethodsPath() {
-		return getPath(ResultScope.ALL_TOTAL_METHODS);
+	public PathBuilder getBuilder(ResultScope scope) {
+		return new PathBuilder(scope);
 	}
 
 	/**
 	 * Returns the path to the filtered methods consumption evolution folder
 	 *
-	 * @param methodName TODO
+	 * @param methodName name of the method under study
 	 *
 	 * @return the path to the filtered methods consumption evolution folder
 	 */
-	public Path getFilteredEvolutionPath(String methodName) {
+	Path getFilteredEvolutionPath(String methodName) {
 		return new PathBuilder(ResultScope.FILTERED_EVOLUTION).withMethodName(methodName).build();
 	}
 
 	/**
-	 * Returns the path to the filtered call trees runtime consumption file
+	 * Generic path getter, wraps around the {@link PathBuilder} Useful for the
+	 * cases where just the scope is enough
 	 *
-	 * @param timestamped if the file must have the current timestamp in its name
-	 * @return the path to the filtered call trees runtime consumption file
+	 * @param scope scope of the result
+	 * @return the corresponding Path
 	 */
-	public Path getFilteredRuntimeCallTreePath(boolean timestamped) {
-		return new PathBuilder(ResultScope.FILTERED_RUNTIME_CALL_TREE).withTimestamp(timestamped).build();
-	}
-
-	/**
-	 * Returns the path to the filtered methods runtime consumption file
-	 *
-	 * @param timestamped if the file must have the current timestamp in its name
-	 * @return the path to the filtered methods runtime consumption file
-	 */
-	public Path getFilteredRuntimeMethodsPath(boolean timestamped) {
-		return new PathBuilder(ResultScope.FILTERED_RUNTIME_METHODS).withTimestamp(timestamped).build();
-	}
-
-	/**
-	 * Returns the path to the filtered call trees total consumption file
-	 *
-	 * @return the path to the filtered call trees total consumption file
-	 */
-	public Path getFilteredTotalCallTreePath() {
-		return getPath(ResultScope.FILTERED_TOTAL_CALL_TREE);
-	}
-
-	/**
-	 * Returns the path to the filtered methods total consumption file
-	 *
-	 * @return the path to the filtered methods total consumption file
-	 */
-	public Path getFilteredTotalMethodsPath() {
-		return getPath(ResultScope.FILTERED_TOTAL_METHODS);
-	}
-
-	public Path getPath(ResultScope scope) {
+	Path getPath(ResultScope scope) {
 		return new PathBuilder(scope).build();
 	}
 

--- a/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
@@ -42,10 +42,10 @@ public class ResultTreeManager {
 
     private AgentProperties properties;
 
-    //The directory where the result of the current execution will be written
+    // The directory where the result of the current execution will be written
     private String runDirectoryPath;
 
-    //All leaf directory paths
+    // All leaf directory paths
     private String allTotalMethodsPath;
     private String filteredTotalMethodsPath;
     private String allRuntimeMethodsPath;
@@ -68,7 +68,7 @@ public class ResultTreeManager {
     public ResultTreeManager(AgentProperties properties, long pid, long startTimestamp) {
         this.properties = properties;
         
-        //Building the path of all the directories
+        // Building the path of all the directories
         this.runDirectoryPath =  GLOBAL_RESULT_DIRECTORY_NAME + "/" + String.format("%d-%d", pid, startTimestamp);
 
         String allDirectoryPath      = runDirectoryPath + "/" + ALL_DIRECTORY_NAME;
@@ -91,49 +91,51 @@ public class ResultTreeManager {
     }
 
     /**
-     * Creates the tree hierarchy. Creates the required folder, if they do not exists yet.
+     * Creates the tree hierarchy. Creates the required folder, if they do not exist yet.
      * Only the necessary folders are created, depending on the provided configuration properties.
-     * @return a boolean indicating werther an error occurs while creating the folder hierarchy (false), or no (true).
+     * @return a boolean indicating whether an error occurs while creating the folder hierarchy (false), or no (true).
      */
     public boolean create() {
-        //This boolean acts as a check. If an error occurs during the intialization of the file hierarchy, the method will continue its execution, as other directories may be created sucessfully, but this boolean will be set to false, to indicate that an error occured.
+        // This boolean acts as a check. If an error occurs during the initialization of the file hierarchy, the method will 
+        // continue its execution, as other directories may be created successfully, but this boolean will be set to false,
+        // to indicate that an error occurred.
         boolean verif = true; 
 
-        logger.log(Level.INFO, String.format("Results will be stored in %s/", this.runDirectoryPath));
+        logger.log(Level.INFO, String.format("Results will be stored in %s%s", this.runDirectoryPath, File.separator));
 
-        //List of all the directories that will be created
+        // List of all the directories that will be created
         List<String> directoriesToCreate = new ArrayList<>();
 
-        //Mandatory directories (directories that do not depend of configuration properties)
+        // Mandatory directories (directories that do not depend of configuration properties)
         directoriesToCreate.add(this.allTotalMethodsPath);
         directoriesToCreate.add(this.filteredTotalMethodsPath);
 
-        //Optional directories (directories that depends of configuration properties)
-        //Runtime
+        // Optional directories (directories that depends of configuration properties)
+        // Runtime
         if (properties.savesRuntimeData()) {
             directoriesToCreate.add(this.allRuntimeMethodsPath);
             directoriesToCreate.add(this.filteredRuntimeMethodsPath);
         }
 
-        //Call trees
+        // Call trees
         if (properties.callTreesConsumption()) {
-            //Runtime
+            // Runtime
             if (properties.saveCallTreesRuntimeData()) {
                 directoriesToCreate.add(this.allRuntimeCallTreePath);
                 directoriesToCreate.add(this.filteredRuntimeCallTreePath);
             }
-            //Total
+            // Total
             directoriesToCreate.add(this.allTotalCallTreePath);
             directoriesToCreate.add(this.filteredTotalCallTreePath);
         }
 
-        //Methods consumption evolution
+        // Methods consumption evolution
         if (properties.trackConsumptionEvolution()) {
             directoriesToCreate.add(this.allEvolutionPath);
             directoriesToCreate.add(this.filteredEvolutionPath);
         }
 
-        //Creating all the directories
+        // Creating all the directories
         for (String dirPath : directoriesToCreate) {
             File dir = new File(dirPath);
             if (!dir.exists() && !dir.mkdirs()) {

--- a/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultTreeManager.java
@@ -14,7 +14,11 @@ import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -29,39 +33,99 @@ import org.noureddine.joularjx.utils.JoularJXLogging;
  */
 public class ResultTreeManager {
 
+	/**
+	 * Builder for creating a {@link Path} object based on the specified attributes.
+	 */
+	public class PathBuilder {
+
+		private boolean timestamp;
+		private ResultScope scope;
+		private String methodName;
+
+		/**
+		 * @param scope the scope
+		 */
+		public PathBuilder(ResultScope scope) {
+			this.scope = scope;
+		}
+
+		/**
+		 * Builds the {@link Path} based on the current state of the builder.
+		 *
+		 * @return a constructed {@link Path} instance
+		 */
+		public Path build() {
+			final StringJoiner joiner = new StringJoiner("-", "joularJX-", "");
+			joiner.add(String.valueOf(pid));
+			if (timestamp) {
+				joiner.add(String.valueOf(System.currentTimeMillis()));
+			}
+			if (Objects.nonNull(methodName)) {
+				joiner.add(methodName);
+			}
+			joiner.add(scope.getScope()).add(scope.getSuffix());
+
+			final String fileName = joiner.toString();
+			return leafPaths.get(scope).resolve(fileName);
+		}
+
+		/**
+		 * Sets the method name
+		 *
+		 * @param methodName the method name
+		 * @return this builder instance
+		 */
+		public PathBuilder withMethodName(String methodName) {
+			this.methodName = methodName;
+			return this;
+		}
+
+		/**
+		 * Sets the result scope.
+		 *
+		 * @param scope the {@link ResultScope} to set
+		 * @return this builder instance
+		 */
+		public PathBuilder withScope(ResultScope scope) {
+			this.scope = scope;
+			return this;
+		}
+
+		/**
+		 * Sets whether to include the current timestamp.
+		 *
+		 * @param timestamp true to include timestamp, false otherwise
+		 * @return this builder instance
+		 */
+		public PathBuilder withTimestamp(boolean timestamp) {
+			this.timestamp = timestamp;
+			return this;
+		}
+	}
+
 	private static final Logger logger = JoularJXLogging.getLogger();
 
 	// Folders names
 	public final static String GLOBAL_RESULT_DIRECTORY_NAME = "joularjx-result";
-
 	public final static String ALL_DIRECTORY_NAME = "all";
-	public final static String FILTERED_DIRECTORY_NAME = "app";
 
+	public final static String FILTERED_DIRECTORY_NAME = "app";
 	public final static String RUNTIME_DIRECTORY_NAME = "runtime";
 	public final static String TOTAL_DIRECTORY_NAME = "total";
-	public final static String EVOLUTION_DIRECTORY_NAME = "evolution";
 
+	public final static String EVOLUTION_DIRECTORY_NAME = "evolution";
 	public final static String CALLTREE_DIRECTORY_NAME = "calltrees";
+
 	public final static String METHOD_DIRECTORY_NAME = "methods";
 
 	private final AgentProperties properties;
 
+	private final long pid;
+
 	// The directory where the result of the current execution will be written
 	private final Path runDirectoryPath;
-
 	// All leaf directory paths
-	private final Path allTotalMethodsPath;
-	private final Path filteredTotalMethodsPath;
-	private final Path allRuntimeMethodsPath;
-	private final Path filteredRuntimeMethodsPath;
-
-	private final Path allRuntimeCallTreePath;
-	private final Path filteredRuntimeCallTreePath;
-	private final Path allTotalCallTreePath;
-	private final Path filteredTotalCallTreePath;
-
-	private final Path allEvolutionPath;
-	private final Path filteredEvolutionPath;
+	private final Map<ResultScope, Path> leafPaths;
 
 	/**
 	 * Creates a new ResultTreeManager. All the filepaths will be initialized (but
@@ -75,6 +139,8 @@ public class ResultTreeManager {
 	 */
 	public ResultTreeManager(AgentProperties properties, long pid, long startTimestamp) {
 		this.properties = properties;
+		this.pid = pid;
+		this.leafPaths = new HashMap<>(ResultScope.values().length);
 
 		// Building the path of all the directories
 		this.runDirectoryPath = Paths.get(GLOBAL_RESULT_DIRECTORY_NAME, String.format("%d-%d", pid, startTimestamp));
@@ -82,32 +148,35 @@ public class ResultTreeManager {
 		final Path allDirectoryPath = runDirectoryPath.resolve(ALL_DIRECTORY_NAME);
 		final Path filteredDirectoryPath = runDirectoryPath.resolve(FILTERED_DIRECTORY_NAME);
 
-		this.allTotalMethodsPath = allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME);
-		this.filteredTotalMethodsPath = filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME)
-				.resolve(METHOD_DIRECTORY_NAME);
-		this.allRuntimeMethodsPath = allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME);
-		this.filteredRuntimeMethodsPath = filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME)
-				.resolve(METHOD_DIRECTORY_NAME);
+		leafPaths.put(ResultScope.ALL_TOTAL_METHODS,
+				allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.FILTERED_TOTAL_METHODS,
+				filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.ALL_RUNTIME_METHODS,
+				allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.FILTERED_RUNTIME_METHODS,
+				filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(METHOD_DIRECTORY_NAME));
 
-		this.allRuntimeCallTreePath = allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME);
-		this.filteredRuntimeCallTreePath = filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME)
-				.resolve(CALLTREE_DIRECTORY_NAME);
-		this.allTotalCallTreePath = allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME);
-		this.filteredTotalCallTreePath = filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME)
-				.resolve(CALLTREE_DIRECTORY_NAME);
+		leafPaths.put(ResultScope.ALL_RUNTIME_CALL_TREE,
+				allDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.FILTERED_RUNTIME_CALL_TREE,
+				filteredDirectoryPath.resolve(RUNTIME_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.ALL_TOTAL_CALL_TREE,
+				allDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.FILTERED_TOTAL_CALL_TREE,
+				filteredDirectoryPath.resolve(TOTAL_DIRECTORY_NAME).resolve(CALLTREE_DIRECTORY_NAME));
 
-		this.allEvolutionPath = allDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME);
-		this.filteredEvolutionPath = filteredDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME);
-
+		leafPaths.put(ResultScope.ALL_EVOLUTION, allDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME));
+		leafPaths.put(ResultScope.FILTERED_EVOLUTION, filteredDirectoryPath.resolve(EVOLUTION_DIRECTORY_NAME));
 	}
 
 	/**
-	 * Creates the tree hierarchy. Creates the required folder, if they do not exist
+	 * Creates the tree hierarchy. Creates the required folders, if they do not exist
 	 * yet. Only the necessary folders are created, depending on the provided
 	 * configuration properties.
 	 *
 	 * @return a boolean indicating whether an error occurs while creating the
-	 *         folder hierarchy (false), or no (true).
+	 *         folder hierarchy (false), or not (true).
 	 */
 	public boolean create() {
 		// This boolean acts as a check. If an error occurs during the initialization of
@@ -124,32 +193,32 @@ public class ResultTreeManager {
 
 		// Mandatory directories (directories that do not depend of configuration
 		// properties)
-		directoriesToCreate.add(this.allTotalMethodsPath);
-		directoriesToCreate.add(this.filteredTotalMethodsPath);
+		directoriesToCreate.add(this.leafPaths.get(ResultScope.ALL_TOTAL_METHODS));
+		directoriesToCreate.add(this.leafPaths.get(ResultScope.FILTERED_TOTAL_METHODS));
 
 		// Optional directories (directories that depends of configuration properties)
 		// Runtime
 		if (properties.savesRuntimeData()) {
-			directoriesToCreate.add(this.allRuntimeMethodsPath);
-			directoriesToCreate.add(this.filteredRuntimeMethodsPath);
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.ALL_RUNTIME_METHODS));
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.FILTERED_RUNTIME_METHODS));
 		}
 
 		// Call trees
 		if (properties.callTreesConsumption()) {
 			// Runtime
 			if (properties.saveCallTreesRuntimeData()) {
-				directoriesToCreate.add(this.allRuntimeCallTreePath);
-				directoriesToCreate.add(this.filteredRuntimeCallTreePath);
+				directoriesToCreate.add(this.leafPaths.get(ResultScope.ALL_RUNTIME_CALL_TREE));
+				directoriesToCreate.add(this.leafPaths.get(ResultScope.FILTERED_RUNTIME_CALL_TREE));
 			}
 			// Total
-			directoriesToCreate.add(this.allTotalCallTreePath);
-			directoriesToCreate.add(this.filteredTotalCallTreePath);
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.ALL_TOTAL_CALL_TREE));
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.FILTERED_TOTAL_CALL_TREE));
 		}
 
 		// Methods consumption evolution
 		if (properties.trackConsumptionEvolution()) {
-			directoriesToCreate.add(this.allEvolutionPath);
-			directoriesToCreate.add(this.filteredEvolutionPath);
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.ALL_EVOLUTION));
+			directoriesToCreate.add(this.leafPaths.get(ResultScope.FILTERED_EVOLUTION));
 		}
 
 		// Creating all the directories
@@ -167,91 +236,103 @@ public class ResultTreeManager {
 	/**
 	 * Returns the path to the methods consumption evolution folder
 	 *
+	 * @param methodName name of the method being tracked
+	 *
 	 * @return the path to the methods consumption evolution folder
 	 */
-	public Path getAllEvolutionPath() {
-		return this.allEvolutionPath;
+	public Path getAllEvolutionPath(String methodName) {
+		return new PathBuilder(ResultScope.ALL_EVOLUTION).withMethodName(methodName).build();
 	}
 
 	/**
-	 * Returns the path to the call trees runtime consumption folder
+	 * Returns the path to the call trees runtime consumption file
 	 *
-	 * @return the path to the call trees runtime consumption folder
+	 * @param timestamped if the file must have the current timestamp in its name
+	 * @return the path to the call trees runtime consumption file
 	 */
-	public Path getAllRuntimeCallTreePath() {
-		return this.allRuntimeCallTreePath;
+	public Path getAllRuntimeCallTreePath(boolean timestamped) {
+		return new PathBuilder(ResultScope.ALL_RUNTIME_CALL_TREE).withTimestamp(timestamped).build();
 	}
 
 	/**
-	 * Returns the path to the methods runtime consumption folder
+	 * Returns the path to the methods runtime consumption file
 	 *
-	 * @return the path to the methods runtime consumption folder
+	 * @param timestamped if the file must have the current timestamp in its name
+	 * @return the path to the methods runtime consumption file
 	 */
-	public Path getAllRuntimeMethodsPath() {
-		return this.allRuntimeMethodsPath;
+	public Path getAllRuntimeMethodsPath(boolean timestamped) {
+		return new PathBuilder(ResultScope.ALL_RUNTIME_METHODS).withTimestamp(timestamped).build();
 	}
 
 	/**
-	 * Returns the path to the call trees total consumption folder
+	 * Returns the path to the call trees total consumption file
 	 *
-	 * @return the path to the call trees total consumption folder
+	 * @return the path to the call trees total consumption file
 	 */
 	public Path getAllTotalCallTreePath() {
-		return this.allTotalCallTreePath;
+		return getPath(ResultScope.ALL_TOTAL_CALL_TREE);
 	}
 
 	/**
-	 * Returns the path to the methods total consumption folder
+	 * Returns the path to the methods total consumption file
 	 *
-	 * @return the path to the methods total consumption folder
+	 * @return the path to the methods total consumption file
 	 */
 	public Path getAllTotalMethodsPath() {
-		return this.allTotalMethodsPath;
+		return getPath(ResultScope.ALL_TOTAL_METHODS);
 	}
 
 	/**
 	 * Returns the path to the filtered methods consumption evolution folder
 	 *
+	 * @param methodName TODO
+	 *
 	 * @return the path to the filtered methods consumption evolution folder
 	 */
-	public Path getFilteredEvolutionPath() {
-		return this.filteredEvolutionPath;
+	public Path getFilteredEvolutionPath(String methodName) {
+		return new PathBuilder(ResultScope.FILTERED_EVOLUTION).withMethodName(methodName).build();
 	}
 
 	/**
-	 * Returns the path to the filtered call trees runtime consumption folder
+	 * Returns the path to the filtered call trees runtime consumption file
 	 *
-	 * @return the path to the filtered call trees runtime consumption folder
+	 * @param timestamped if the file must have the current timestamp in its name
+	 * @return the path to the filtered call trees runtime consumption file
 	 */
-	public Path getFilteredRuntimeCallTreePath() {
-		return this.filteredRuntimeCallTreePath;
+	public Path getFilteredRuntimeCallTreePath(boolean timestamped) {
+		return new PathBuilder(ResultScope.FILTERED_RUNTIME_CALL_TREE).withTimestamp(timestamped).build();
 	}
 
 	/**
-	 * Returns the path to the filtered methods runtime consumption folder
+	 * Returns the path to the filtered methods runtime consumption file
 	 *
-	 * @return the path to the filtered methods runtime consumption folder
+	 * @param timestamped if the file must have the current timestamp in its name
+	 * @return the path to the filtered methods runtime consumption file
 	 */
-	public Path getFilteredRuntimeMethodsPath() {
-		return this.filteredRuntimeMethodsPath;
+	public Path getFilteredRuntimeMethodsPath(boolean timestamped) {
+		return new PathBuilder(ResultScope.FILTERED_RUNTIME_METHODS).withTimestamp(timestamped).build();
 	}
 
 	/**
-	 * Returns the path to the filtered call trees total consumption folder
+	 * Returns the path to the filtered call trees total consumption file
 	 *
-	 * @return the path to the filtered call trees total consumption folder
+	 * @return the path to the filtered call trees total consumption file
 	 */
 	public Path getFilteredTotalCallTreePath() {
-		return this.filteredTotalCallTreePath;
+		return getPath(ResultScope.FILTERED_TOTAL_CALL_TREE);
 	}
 
 	/**
-	 * Returns the path to the filtered methods total consumption folder
+	 * Returns the path to the filtered methods total consumption file
 	 *
-	 * @return the path to the filtered methods total consumption folder
+	 * @return the path to the filtered methods total consumption file
 	 */
 	public Path getFilteredTotalMethodsPath() {
-		return this.filteredTotalMethodsPath;
+		return getPath(ResultScope.FILTERED_TOTAL_METHODS);
+	}
+
+	public Path getPath(ResultScope scope) {
+		return new PathBuilder(scope).build();
 	}
 
 }

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
@@ -11,6 +11,7 @@
 package org.noureddine.joularjx.result;
 
 import java.io.IOException;
+import java.util.Properties;
 
 public interface ResultWriter {
 
@@ -20,6 +21,18 @@ public interface ResultWriter {
 	 * @throws IOException in case of error
 	 */
 	void closeTarget() throws IOException;
+
+	void setProperties(Properties props);
+
+	/**
+	 * Set the target for this writer, aka the place where the data will be written.
+	 * Call this method before any writing operation.
+	 *
+	 * @param scope     type of the target
+	 * @param overwrite true to overwrite any existing data in the target
+	 * @throws IOException in case of error
+	 */
+	void setTarget(ResultScope scope, boolean overwrite) throws IOException;
 
 	/**
 	 * Set the target for this writer, aka the place where the data will be written.

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
@@ -11,7 +11,8 @@
 package org.noureddine.joularjx.result;
 
 import java.io.IOException;
-import java.util.Properties;
+
+import org.noureddine.joularjx.utils.AgentProperties;
 
 public interface ResultWriter {
 
@@ -22,7 +23,7 @@ public interface ResultWriter {
 	 */
 	void closeTarget() throws IOException;
 
-	void setProperties(Properties props);
+	void setProperties(AgentProperties props, long pid, long timestamp);
 
 	/**
 	 * Set the target for this writer, aka the place where the data will be written.

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
@@ -17,36 +17,34 @@ import org.noureddine.joularjx.utils.AgentProperties;
 public interface ResultWriter {
 
 	/**
-	 * Close the target. Call this method once all writing operations have completed
+	 * Closes the target. Call this method once all writing operations have
+	 * completed
 	 *
 	 * @throws IOException in case of error
 	 */
 	void closeTarget() throws IOException;
 
-	void setProperties(AgentProperties props, long pid, long timestamp);
+	/**
+	 * Initializes this writer. This method should be called only once at instance
+	 * creation.
+	 *
+	 * @param props     properties
+	 * @param pid       pid of the software being monitored
+	 * @param timestamp current execution timestamp
+	 */
+	void initialize(AgentProperties props, long pid, long timestamp);
 
 	/**
-	 * Set the target for this writer, aka the place where the data will be written.
-	 * Call this method before any writing operation.
+	 * Configures this writer for the current write operation. This method should be
+	 * called once for each different type of data being written.
 	 *
-	 * @param scope     type of the target
-	 * @param overwrite true to overwrite any existing data in the target
+	 * @param configuration current configuration to use for this operation
 	 * @throws IOException in case of error
 	 */
-	void setTarget(ResultScope scope, boolean overwrite) throws IOException;
+	void setConfiguration(ResultWriterConfiguration configuration) throws IOException;
 
 	/**
-	 * Set the target for this writer, aka the place where the data will be written.
-	 * Call this method before any writing operation.
-	 *
-	 * @param name      name of the target (can be a file name, for example)
-	 * @param overwrite true to overwrite any existing data in the target
-	 * @throws IOException in case of error
-	 */
-	void setTarget(String name, boolean overwrite) throws IOException;
-
-	/**
-	 * Write a line. {@link #setTarget(String, boolean)} should have been called
+	 * Writes a line. {@link #setTarget(String, boolean)} should have been called
 	 * before using this method.
 	 *
 	 * @param methodName  name of the method

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriter.java
@@ -14,9 +14,30 @@ import java.io.IOException;
 
 public interface ResultWriter {
 
-    void setTarget(String name, boolean overwrite) throws IOException;
+	/**
+	 * Close the target. Call this method once all writing operations have completed
+	 *
+	 * @throws IOException in case of error
+	 */
+	void closeTarget() throws IOException;
 
-    void write(String methodName, double methodPower) throws IOException;
+	/**
+	 * Set the target for this writer, aka the place where the data will be written.
+	 * Call this method before any writing operation.
+	 *
+	 * @param name      name of the target (can be a file name, for example)
+	 * @param overwrite true to overwrite any existing data in the target
+	 * @throws IOException in case of error
+	 */
+	void setTarget(String name, boolean overwrite) throws IOException;
 
-    void closeTarget() throws IOException;
+	/**
+	 * Write a line. {@link #setTarget(String, boolean)} should have been called
+	 * before using this method.
+	 *
+	 * @param methodName  name of the method
+	 * @param methodPower power consumption of the method
+	 * @throws IOException in case of error
+	 */
+	void write(String methodName, double methodPower) throws IOException;
 }

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriterConfiguration.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriterConfiguration.java
@@ -21,24 +21,20 @@ public final class ResultWriterConfiguration {
 	private boolean overwrite;
 
 	/**
-	 * @param scope
+	 * Constructor
+	 *
+	 * @param scope scope of the data to be written
 	 */
 	public ResultWriterConfiguration(ResultScope scope) {
 		this.scope = scope;
 	}
 
 	/**
-	 * @param scope
-	 * @param methodName
-	 */
-	public ResultWriterConfiguration(ResultScope scope, String methodName) {
-		this(scope);
-		this.methodName = methodName;
-	}
-
-	/**
-	 * @param scope
-	 * @param timestamped
+	 * Specialized constructor for timestamped data
+	 *
+	 * @param scope       scope of the data to be written
+	 * @param timestamped true if the data to be written is timestamped, i.e.,
+	 *                    instant data
 	 */
 	public ResultWriterConfiguration(ResultScope scope, boolean timestamped) {
 		this(scope);
@@ -47,30 +43,29 @@ public final class ResultWriterConfiguration {
 	}
 
 	/**
-	 * @return the methodName
+	 * Specialized constructor for methods
+	 *
+	 * @param scope      scope of the data to be written
+	 * @param methodName name of the method
 	 */
+	public ResultWriterConfiguration(ResultScope scope, String methodName) {
+		this(scope);
+		this.methodName = methodName;
+	}
+
 	public String getMethodName() {
 		return methodName;
 	}
 
-	/**
-	 * @return the scope
-	 */
 	public ResultScope getScope() {
 		return scope;
 	}
 
-	/**
-	 * @return the timestamped
-	 */
-	public boolean isTimestamped() {
-		return timestamped;
-	}
-
-	/**
-	 * @return the overwrite
-	 */
 	public boolean isOverwrite() {
 		return overwrite;
+	}
+
+	public boolean isTimestamped() {
+		return timestamped;
 	}
 }

--- a/src/main/java/org/noureddine/joularjx/result/ResultWriterConfiguration.java
+++ b/src/main/java/org/noureddine/joularjx/result/ResultWriterConfiguration.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021-2025, Adel Noureddine, Université de Pau et des Pays de l'Adour.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the
+ * GNU General Public License v3.0 only (GPL-3.0-only)
+ * which accompanies this distribution, and is available at
+ * https://www.gnu.org/licenses/gpl-3.0.en.html
+ *
+ */
+package org.noureddine.joularjx.result;
+
+/**
+ * Generic class to pass configuration to a {@link ResultWriter} instance 
+ * This allows the instance to know which contents will be written to it
+ */
+public final class ResultWriterConfiguration {
+
+	private final ResultScope scope;
+	private String methodName;
+	private boolean timestamped;
+	private boolean overwrite;
+
+	/**
+	 * @param scope
+	 */
+	public ResultWriterConfiguration(ResultScope scope) {
+		this.scope = scope;
+	}
+
+	/**
+	 * @param scope
+	 * @param methodName
+	 */
+	public ResultWriterConfiguration(ResultScope scope, String methodName) {
+		this(scope);
+		this.methodName = methodName;
+	}
+
+	/**
+	 * @param scope
+	 * @param timestamped
+	 */
+	public ResultWriterConfiguration(ResultScope scope, boolean timestamped) {
+		this(scope);
+		this.timestamped = timestamped;
+		this.overwrite = !timestamped;
+	}
+
+	/**
+	 * @return the methodName
+	 */
+	public String getMethodName() {
+		return methodName;
+	}
+
+	/**
+	 * @return the scope
+	 */
+	public ResultScope getScope() {
+		return scope;
+	}
+
+	/**
+	 * @return the timestamped
+	 */
+	public boolean isTimestamped() {
+		return timestamped;
+	}
+
+	/**
+	 * @return the overwrite
+	 */
+	public boolean isOverwrite() {
+		return overwrite;
+	}
+}

--- a/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
+++ b/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
@@ -12,6 +12,7 @@ package org.noureddine.joularjx.result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.nio.file.Path;
 import java.util.Random;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -33,105 +34,104 @@ public class ResultTreeManagerTest {
 
         this.appDirectory = String.format("%d-%d", pid, timestamp);
 
-        //For the moment, only peths are tested, so the AgentProperies parameter is not required
+        // For the moment, only paths are tested, so the AgentProperties parameter is not required
         this.manager = new ResultTreeManager(null, pid, timestamp);
     }
 
     @Test
     public void getAllRuntimeMethodsPathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.ALL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.RUNTIME_DIRECTORY_NAME+"/"
-            +ResultTreeManager.METHOD_DIRECTORY_NAME
-            , this.manager.getAllRuntimeMethodsPath());
+    	Path reference = Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME, this.appDirectory, 
+                ResultTreeManager.ALL_DIRECTORY_NAME,
+                ResultTreeManager.RUNTIME_DIRECTORY_NAME,
+                ResultTreeManager.METHOD_DIRECTORY_NAME);
+        assertEquals(reference, this.manager.getAllRuntimeMethodsPath());
     }
 
     @Test
     public void getFilteredRuntimeMethodsPathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-        +this.appDirectory+"/"
-        +ResultTreeManager.FILTERED_DIRECTORY_NAME+"/"
-        +ResultTreeManager.RUNTIME_DIRECTORY_NAME+"/"
-        +ResultTreeManager.METHOD_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+        this.appDirectory,
+        ResultTreeManager.FILTERED_DIRECTORY_NAME,
+        ResultTreeManager.RUNTIME_DIRECTORY_NAME,
+        ResultTreeManager.METHOD_DIRECTORY_NAME)
         , this.manager.getFilteredRuntimeMethodsPath());
     }
 
     @Test
     public void getAllTotalMethodsPathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-        +this.appDirectory+"/"
-        +ResultTreeManager.ALL_DIRECTORY_NAME+"/"
-        +ResultTreeManager.TOTAL_DIRECTORY_NAME+"/"
-        +ResultTreeManager.METHOD_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+        this.appDirectory,
+        ResultTreeManager.ALL_DIRECTORY_NAME,
+        ResultTreeManager.TOTAL_DIRECTORY_NAME,
+        ResultTreeManager.METHOD_DIRECTORY_NAME)
         , this.manager.getAllTotalMethodsPath());
     }
 
     @Test
     public void getFilteredTotalMethodsPathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-        +this.appDirectory+"/"
-        +ResultTreeManager.FILTERED_DIRECTORY_NAME+"/"
-        +ResultTreeManager.TOTAL_DIRECTORY_NAME+"/"
-        +ResultTreeManager.METHOD_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+        this.appDirectory,
+        ResultTreeManager.FILTERED_DIRECTORY_NAME,
+        ResultTreeManager.TOTAL_DIRECTORY_NAME,
+        ResultTreeManager.METHOD_DIRECTORY_NAME)
         , this.manager.getFilteredTotalMethodsPath());
     }
 
     @Test
     public void getAllRuntimeCallTreePathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.ALL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.RUNTIME_DIRECTORY_NAME+"/"
-            +ResultTreeManager.CALLTREE_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.ALL_DIRECTORY_NAME,
+            ResultTreeManager.RUNTIME_DIRECTORY_NAME,
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
             , this.manager.getAllRuntimeCallTreePath());
     }
 
     @Test
     public void getFilteredRuntimeCallTreePathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.FILTERED_DIRECTORY_NAME+"/"
-            +ResultTreeManager.RUNTIME_DIRECTORY_NAME+"/"
-            +ResultTreeManager.CALLTREE_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.FILTERED_DIRECTORY_NAME,
+            ResultTreeManager.RUNTIME_DIRECTORY_NAME,
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
             , this.manager.getFilteredRuntimeCallTreePath());
     }
 
     @Test
     public void getAllTotalCallTreePathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.ALL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.TOTAL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.CALLTREE_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.ALL_DIRECTORY_NAME,
+            ResultTreeManager.TOTAL_DIRECTORY_NAME,
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
             , this.manager.getAllTotalCallTreePath());
     }
 
     @Test
     public void getFilteredTotalCallTreePathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.FILTERED_DIRECTORY_NAME+"/"
-            +ResultTreeManager.TOTAL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.CALLTREE_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.FILTERED_DIRECTORY_NAME,
+            ResultTreeManager.TOTAL_DIRECTORY_NAME,
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
             , this.manager.getFilteredTotalCallTreePath());
     }
 
     @Test
     public void getAllEvolutionPathTest(){
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.ALL_DIRECTORY_NAME+"/"
-            +ResultTreeManager.EVOLUTION_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.ALL_DIRECTORY_NAME,
+            ResultTreeManager.EVOLUTION_DIRECTORY_NAME)
             , this.manager.getAllEvolutionPath());
     }
 
     @Test
     public void getFilteredEvolutionPathTest() {
-        assertEquals(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME+"/"
-            +this.appDirectory+"/"
-            +ResultTreeManager.FILTERED_DIRECTORY_NAME+"/"
-            +ResultTreeManager.EVOLUTION_DIRECTORY_NAME
+        assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
+            this.appDirectory,
+            ResultTreeManager.FILTERED_DIRECTORY_NAME,
+            ResultTreeManager.EVOLUTION_DIRECTORY_NAME)
             , this.manager.getFilteredEvolutionPath());
     }
 }

--- a/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
+++ b/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
@@ -43,8 +43,9 @@ public class ResultTreeManagerTest {
     	Path reference = Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME, this.appDirectory, 
                 ResultTreeManager.ALL_DIRECTORY_NAME,
                 ResultTreeManager.RUNTIME_DIRECTORY_NAME,
-                ResultTreeManager.METHOD_DIRECTORY_NAME);
-        assertEquals(reference, this.manager.getAllRuntimeMethodsPath());
+                ResultTreeManager.METHOD_DIRECTORY_NAME,
+                String.format("joularJX-%d-all-methods-power", pid));
+        assertEquals(reference, this.manager.getPath(ResultScope.ALL_RUNTIME_METHODS));
     }
 
     @Test
@@ -53,8 +54,9 @@ public class ResultTreeManagerTest {
         this.appDirectory,
         ResultTreeManager.FILTERED_DIRECTORY_NAME,
         ResultTreeManager.RUNTIME_DIRECTORY_NAME,
-        ResultTreeManager.METHOD_DIRECTORY_NAME)
-        , this.manager.getFilteredRuntimeMethodsPath());
+        ResultTreeManager.METHOD_DIRECTORY_NAME,
+        String.format("joularJX-%d-filtered-methods-power", pid))
+        , this.manager.getPath(ResultScope.FILTERED_RUNTIME_METHODS));
     }
 
     @Test
@@ -63,7 +65,8 @@ public class ResultTreeManagerTest {
         this.appDirectory,
         ResultTreeManager.ALL_DIRECTORY_NAME,
         ResultTreeManager.TOTAL_DIRECTORY_NAME,
-        ResultTreeManager.METHOD_DIRECTORY_NAME)
+        ResultTreeManager.METHOD_DIRECTORY_NAME,
+        String.format("joularJX-%d-all-methods-energy", pid))
         , this.manager.getAllTotalMethodsPath());
     }
 
@@ -73,7 +76,8 @@ public class ResultTreeManagerTest {
         this.appDirectory,
         ResultTreeManager.FILTERED_DIRECTORY_NAME,
         ResultTreeManager.TOTAL_DIRECTORY_NAME,
-        ResultTreeManager.METHOD_DIRECTORY_NAME)
+        ResultTreeManager.METHOD_DIRECTORY_NAME,
+        String.format("joularJX-%d-filtered-methods-energy", pid))
         , this.manager.getFilteredTotalMethodsPath());
     }
 
@@ -83,8 +87,9 @@ public class ResultTreeManagerTest {
             this.appDirectory,
             ResultTreeManager.ALL_DIRECTORY_NAME,
             ResultTreeManager.RUNTIME_DIRECTORY_NAME,
-            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
-            , this.manager.getAllRuntimeCallTreePath());
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME,
+            String.format("joularJX-%d-all-call-trees-power", pid))
+            , this.manager.getPath(ResultScope.ALL_RUNTIME_CALL_TREE));
     }
 
     @Test
@@ -93,8 +98,9 @@ public class ResultTreeManagerTest {
             this.appDirectory,
             ResultTreeManager.FILTERED_DIRECTORY_NAME,
             ResultTreeManager.RUNTIME_DIRECTORY_NAME,
-            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
-            , this.manager.getFilteredRuntimeCallTreePath());
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME,
+            String.format("joularJX-%d-filtered-call-trees-power", pid))
+            , this.manager.getPath(ResultScope.FILTERED_RUNTIME_CALL_TREE));
     }
 
     @Test
@@ -103,7 +109,8 @@ public class ResultTreeManagerTest {
             this.appDirectory,
             ResultTreeManager.ALL_DIRECTORY_NAME,
             ResultTreeManager.TOTAL_DIRECTORY_NAME,
-            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME,
+            String.format("joularJX-%d-all-call-trees-energy", pid))
             , this.manager.getAllTotalCallTreePath());
     }
 
@@ -113,7 +120,8 @@ public class ResultTreeManagerTest {
             this.appDirectory,
             ResultTreeManager.FILTERED_DIRECTORY_NAME,
             ResultTreeManager.TOTAL_DIRECTORY_NAME,
-            ResultTreeManager.CALLTREE_DIRECTORY_NAME)
+            ResultTreeManager.CALLTREE_DIRECTORY_NAME,
+            String.format("joularJX-%d-filtered-call-trees-energy", pid))
             , this.manager.getFilteredTotalCallTreePath());
     }
 
@@ -122,8 +130,9 @@ public class ResultTreeManagerTest {
         assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
             this.appDirectory,
             ResultTreeManager.ALL_DIRECTORY_NAME,
-            ResultTreeManager.EVOLUTION_DIRECTORY_NAME)
-            , this.manager.getAllEvolutionPath());
+            ResultTreeManager.EVOLUTION_DIRECTORY_NAME,
+            String.format("joularJX-%d-all-evolution", pid))
+            , this.manager.getAllEvolutionPath(null));
     }
 
     @Test
@@ -131,7 +140,8 @@ public class ResultTreeManagerTest {
         assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
             this.appDirectory,
             ResultTreeManager.FILTERED_DIRECTORY_NAME,
-            ResultTreeManager.EVOLUTION_DIRECTORY_NAME)
-            , this.manager.getFilteredEvolutionPath());
+            ResultTreeManager.EVOLUTION_DIRECTORY_NAME,
+            String.format("joularJX-%d-filtered-evolution", pid))
+            , this.manager.getFilteredEvolutionPath(null));
     }
 }

--- a/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
+++ b/src/test/java/org/noureddine/joularjx/result/ResultTreeManagerTest.java
@@ -11,9 +11,12 @@
 package org.noureddine.joularjx.result;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,12 +43,31 @@ public class ResultTreeManagerTest {
 
     @Test
     public void getAllRuntimeMethodsPathTest() {
-    	Path reference = Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME, this.appDirectory, 
+        Path reference = Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME, this.appDirectory, 
                 ResultTreeManager.ALL_DIRECTORY_NAME,
                 ResultTreeManager.RUNTIME_DIRECTORY_NAME,
                 ResultTreeManager.METHOD_DIRECTORY_NAME,
                 String.format("joularJX-%d-all-methods-power", pid));
         assertEquals(reference, this.manager.getPath(ResultScope.ALL_RUNTIME_METHODS));
+    }
+    
+    @Test
+    public void getAllRuntimeMethodsPathTimestampedTest() {
+    	// Note: this timestamp test may be better either with a mock library or an API change on the Builder
+        long timestamp1 = System.currentTimeMillis();
+        Pattern pattern = Pattern.compile("joularJX-(-?\\d+)-(\\d+)-all-methods-power");
+        Path reference = Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME, this.appDirectory, 
+                ResultTreeManager.ALL_DIRECTORY_NAME,
+                ResultTreeManager.RUNTIME_DIRECTORY_NAME,
+                ResultTreeManager.METHOD_DIRECTORY_NAME);
+        Path result = this.manager.getBuilder(ResultScope.ALL_RUNTIME_METHODS).withTimestamp(true).build();
+        long timestamp2 = System.currentTimeMillis();
+        assertEquals(reference, result.getParent());
+        Matcher match = pattern.matcher(result.getFileName().toString());
+        match.find();
+        assertEquals(pid, Long.parseLong(match.group(1)));
+        long timestamp = Long.parseLong(match.group(2));
+        assertTrue(timestamp1 <= timestamp && timestamp2 >= timestamp);
     }
 
     @Test
@@ -67,7 +89,7 @@ public class ResultTreeManagerTest {
         ResultTreeManager.TOTAL_DIRECTORY_NAME,
         ResultTreeManager.METHOD_DIRECTORY_NAME,
         String.format("joularJX-%d-all-methods-energy", pid))
-        , this.manager.getAllTotalMethodsPath());
+        , this.manager.getPath(ResultScope.ALL_TOTAL_METHODS));
     }
 
     @Test
@@ -78,7 +100,7 @@ public class ResultTreeManagerTest {
         ResultTreeManager.TOTAL_DIRECTORY_NAME,
         ResultTreeManager.METHOD_DIRECTORY_NAME,
         String.format("joularJX-%d-filtered-methods-energy", pid))
-        , this.manager.getFilteredTotalMethodsPath());
+        , this.manager.getPath(ResultScope.FILTERED_TOTAL_METHODS));
     }
 
     @Test
@@ -111,7 +133,7 @@ public class ResultTreeManagerTest {
             ResultTreeManager.TOTAL_DIRECTORY_NAME,
             ResultTreeManager.CALLTREE_DIRECTORY_NAME,
             String.format("joularJX-%d-all-call-trees-energy", pid))
-            , this.manager.getAllTotalCallTreePath());
+            , this.manager.getPath(ResultScope.ALL_TOTAL_CALL_TREE));
     }
 
     @Test
@@ -122,26 +144,28 @@ public class ResultTreeManagerTest {
             ResultTreeManager.TOTAL_DIRECTORY_NAME,
             ResultTreeManager.CALLTREE_DIRECTORY_NAME,
             String.format("joularJX-%d-filtered-call-trees-energy", pid))
-            , this.manager.getFilteredTotalCallTreePath());
+            , this.manager.getPath(ResultScope.FILTERED_TOTAL_CALL_TREE));
     }
 
     @Test
     public void getAllEvolutionPathTest(){
+        String method = "traditional";
         assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
             this.appDirectory,
             ResultTreeManager.ALL_DIRECTORY_NAME,
             ResultTreeManager.EVOLUTION_DIRECTORY_NAME,
-            String.format("joularJX-%d-all-evolution", pid))
-            , this.manager.getAllEvolutionPath(null));
+            String.format("joularJX-%d-%s-evolution", pid, method))
+            , this.manager.getAllEvolutionPath(method));
     }
 
     @Test
     public void getFilteredEvolutionPathTest() {
+        String method = "traditional";
         assertEquals(Path.of(ResultTreeManager.GLOBAL_RESULT_DIRECTORY_NAME,
             this.appDirectory,
             ResultTreeManager.FILTERED_DIRECTORY_NAME,
             ResultTreeManager.EVOLUTION_DIRECTORY_NAME,
-            String.format("joularJX-%d-filtered-evolution", pid))
-            , this.manager.getFilteredEvolutionPath(null));
+            String.format("joularJX-%d-%s-evolution", pid, method))
+            , this.manager.getFilteredEvolutionPath(method));
     }
 }


### PR DESCRIPTION
Once completed, this PR aims to bring Service-Provider Interface to joularjx for outputting results. To do so, as was pointed out in another ticket, some refactoring is necessary. 

Summary:
- Use `ResultWriter` as interface for the service. `CsvResultWriter` then becomes an implementation. Use Google's `autoservice` Maven package for convenience.
- Add some methods to the interface to make it more generic (some future implementations may not write files, for example)
- Introduce a new enum to tell the different outputs apart, called `ResultScope`. It may be wise to consider the existing `Scope` enum class because there is a small overlap in functionality between the two.
- Introduce a `ResultWriterConfiguration` class to forward relevant data to the writers
- `ResultTreeManager` is now used directly from `CsvResultWriter` instead of the *Handler calling classes. This class has been completely refactored thanks to the introduction of the `ResultScope` enum. As a result, most of the methods have disappeared, their functionality now being encapsulated in a Builder subclass.
- Correctly handle lists of `ResultWriter` instead of a single one

Unfortunately, the PR is also cluttered by changes triggered by the automatic formatting rules of my IDE.